### PR TITLE
subfeat/리덕스로 홈 miniProfile 구현

### DIFF
--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -1,11 +1,11 @@
 // 여기에 쓰는건 어때요?
-export declare module globalType {
+declare module globalType {
     //
-    export interface asd {}
+    interface asd {}
 }
 
-export declare module Direct {
-    export interface ChatItem {
+declare module Direct {
+    interface ChatItem {
         id: number;
         avatarImg: string;
         userName: string;

--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -49,9 +49,15 @@ declare module HomeType {
         postUploadDate: string;
         // comment 몇 개 가져오기
     }
+
+    interface ArticleStateProps extends ArticleProps {
+        isFollowing: boolean;
+        followLoading: boolean;
+    }
+
     interface homeStateProps {
         storiesScrollPosition: storiesScrollPositionType;
-        articles: ArticleProps[];
+        articles: ArticleStateProps[];
         // location?
         isLoading: boolean; // 더미 로딩
         isExtraArticleLoading: boolean;
@@ -111,6 +117,10 @@ declare module ModalType {
         memberWebsite: null | string;
     }
 
+    interface MiniProfileStateProps extends MiniProfileProps {
+        isLoading: boolean;
+    }
+
     interface ModalStateProps {
         activatedModal: ActivatedModalType;
         modalPosition?: ModalPositionProps;
@@ -118,7 +128,7 @@ declare module ModalType {
         memberNickname: string;
         memberImageUrl: string;
         postId?: number;
-        miniProfile?: MiniProfileProps;
+        miniProfile?: MiniProfileStateProps;
         isOnMiniProfile: boolean;
     }
 }

--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -58,9 +58,18 @@ declare module HomeType {
         // comment 몇 개 가져오기
     }
 
-    export interface homeModalProps {
-        activatedModal: activatedModalType;
-        handledObj: null;
+    interface ModalPositionProps {
+        top: number;
+        bottom: number;
+        left: number;
+    }
+
+    export interface ModalDTOsProps {
+        activatedModal: ActivatedModalType;
+        modalPosition?: ModalPositionProps;
+        memberNickname?: string;
+        memberImageUrl?: string;
+        postId?: number;
     }
     export interface homeStateProps {
         storiesScrollPosition: storiesScrollPositionType;
@@ -86,6 +95,6 @@ declare module HomeType {
             }[]; // 최신 3개
         } | null;
         isCopiedNotification: boolean;
-        homeModal: homeModalProps;
+        modalDTOs: ModalDTOsProps;
     }
 }

--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -129,6 +129,7 @@ declare module ModalType {
         memberImageUrl: string;
         postId?: number;
         miniProfile?: MiniProfileStateProps;
+        isFollowing?: boolean;
         isOnMiniProfile: boolean;
     }
 }

--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -119,11 +119,11 @@ declare module ModalType {
 
     interface MiniProfileStateProps extends MiniProfileProps {
         isLoading: boolean;
+        modalPosition: ModalPositionProps;
     }
 
     interface ModalStateProps {
         activatedModal: ActivatedModalType;
-        modalPosition?: ModalPositionProps;
         memberUsername: string;
         memberNickname: string;
         memberImageUrl: string;

--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -18,14 +18,6 @@ declare module Direct {
 declare module HomeType {
     type StoriesScrollPositionType = "left" | "right" | "center";
 
-    type ActivatedModalType =
-        | "hover"
-        | "unfollowing"
-        | "report"
-        | "articleMenu"
-        | "shareWith"
-        | null;
-
     interface PostImgTagDTOProps {
         id: number;
         tag: {
@@ -57,20 +49,6 @@ declare module HomeType {
         postUploadDate: string;
         // comment 몇 개 가져오기
     }
-
-    interface ModalPositionProps {
-        top: number;
-        bottom: number;
-        left: number;
-    }
-
-    interface ModalDTOsProps {
-        activatedModal: ActivatedModalType;
-        modalPosition?: ModalPositionProps;
-        memberNickname?: string;
-        memberImageUrl?: string;
-        postId?: number;
-    }
     interface homeStateProps {
         storiesScrollPosition: storiesScrollPositionType;
         articles: ArticleProps[];
@@ -95,6 +73,28 @@ declare module HomeType {
             }[]; // 최신 3개
         } | null;
         isCopiedNotification: boolean;
-        modalDTOs: ModalDTOsProps;
+    }
+}
+
+declare module ModalType {
+    type ActivatedModalType =
+        | "hover"
+        | "unfollowing"
+        | "report"
+        | "articleMenu"
+        | "shareWith"
+        | null;
+    interface ModalPositionProps {
+        top: number;
+        bottom: number;
+        left: number;
+    }
+
+    interface ModalStateProps {
+        activatedModal: ActivatedModalType;
+        modalPosition?: ModalPositionProps;
+        memberNickname?: string;
+        memberImageUrl?: string;
+        postId?: number;
     }
 }

--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -90,11 +90,35 @@ declare module ModalType {
         left: number;
     }
 
+    interface MiniProfileProps {
+        blocked: boolean;
+        blocking: boolean;
+        follower: boolean;
+        following: boolean;
+        followingMemberFollow: string;
+        me: boolean;
+        memberFollowersCount: string;
+        memberFollowingsCount: string;
+        memberImage: {
+            imageUrl: string;
+            imageType: string;
+            imageName: string;
+            imageUUID: string;
+        };
+        memberName: string;
+        memberPosts: { postId: number; postImageUrl: string }[]; // string
+        memberPostsCount: number;
+        memberUsername: string;
+        memberWebsite: null | string;
+    }
+
     interface ModalStateProps {
         activatedModal: ActivatedModalType;
         modalPosition?: ModalPositionProps;
+        memberUsername?: string;
         memberNickname?: string;
         memberImageUrl?: string;
         postId?: number;
+        miniProfile?: MiniProfileProps;
     }
 }

--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -78,7 +78,6 @@ declare module HomeType {
 
 declare module ModalType {
     type ActivatedModalType =
-        | "hover"
         | "unfollowing"
         | "report"
         | "articleMenu"
@@ -97,8 +96,9 @@ declare module ModalType {
         following: boolean;
         followingMemberFollow: string;
         me: boolean;
-        memberFollowersCount: string;
-        memberFollowingsCount: string;
+        memberFollowersCount: number;
+        memberFollowingsCount: number;
+        memberPostsCount: number;
         memberImage: {
             imageUrl: string;
             imageType: string;
@@ -107,7 +107,6 @@ declare module ModalType {
         };
         memberName: string;
         memberPosts: { postId: number; postImageUrl: string }[]; // string
-        memberPostsCount: number;
         memberUsername: string;
         memberWebsite: null | string;
     }
@@ -115,10 +114,11 @@ declare module ModalType {
     interface ModalStateProps {
         activatedModal: ActivatedModalType;
         modalPosition?: ModalPositionProps;
-        memberUsername?: string;
-        memberNickname?: string;
-        memberImageUrl?: string;
+        memberUsername: string;
+        memberNickname: string;
+        memberImageUrl: string;
         postId?: number;
         miniProfile?: MiniProfileProps;
+        isOnMiniProfile: boolean;
     }
 }

--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -16,9 +16,9 @@ export declare module Direct {
 }
 
 declare module HomeType {
-    export type StoriesScrollPositionType = "left" | "right" | "center";
+    type StoriesScrollPositionType = "left" | "right" | "center";
 
-    export type ActivatedModalType =
+    type ActivatedModalType =
         | "hover"
         | "unfollowing"
         | "report"
@@ -26,7 +26,7 @@ declare module HomeType {
         | "shareWith"
         | null;
 
-    export interface PostImgTagDTOProps {
+    interface PostImgTagDTOProps {
         id: number;
         tag: {
             username: string;
@@ -35,7 +35,7 @@ declare module HomeType {
         };
     }
 
-    export interface PostImageDTOProps {
+    interface PostImageDTOProps {
         id: number;
         postImageUrl: string;
         postTagDTOs: PostImgTagDTOProps[];
@@ -64,14 +64,14 @@ declare module HomeType {
         left: number;
     }
 
-    export interface ModalDTOsProps {
+    interface ModalDTOsProps {
         activatedModal: ActivatedModalType;
         modalPosition?: ModalPositionProps;
         memberNickname?: string;
         memberImageUrl?: string;
         postId?: number;
     }
-    export interface homeStateProps {
+    interface homeStateProps {
         storiesScrollPosition: storiesScrollPositionType;
         articles: ArticleProps[];
         // location?

--- a/src/Hooks/useCopy.ts
+++ b/src/Hooks/useCopy.ts
@@ -1,4 +1,8 @@
+import { homeActions } from "app/store/ducks/home/homeSlice";
+import { useAppDispatch } from "app/store/hooks";
+
 const useCopy = (copyValue: string) => {
+    const dispatch = useAppDispatch();
     return () => {
         if (!document.queryCommandSupported("copy")) {
             return alert("복사하기가 지원되지 않는 브라우저입니다.");
@@ -15,8 +19,12 @@ const useCopy = (copyValue: string) => {
         textarea.select();
         document.execCommand("copy");
         document.body.removeChild(textarea);
-        // notification root 작성 후 복사 여부 알려주기
-        // dispatch(notificationActions.appear())
+        dispatch(homeActions.resetModal());
+        dispatch(homeActions.notificateIsCopied());
+        setTimeout(
+            () => dispatch(homeActions.closeIsCopiedNotification()),
+            8500,
+        );
     };
 };
 

--- a/src/Hooks/useCopy.ts
+++ b/src/Hooks/useCopy.ts
@@ -1,4 +1,5 @@
 import { homeActions } from "app/store/ducks/home/homeSlice";
+import { modalActions } from "app/store/ducks/modal/modalSlice";
 import { useAppDispatch } from "app/store/hooks";
 
 const useCopy = (copyValue: string) => {
@@ -19,7 +20,7 @@ const useCopy = (copyValue: string) => {
         textarea.select();
         document.execCommand("copy");
         document.body.removeChild(textarea);
-        dispatch(homeActions.resetModal());
+        dispatch(modalActions.resetModal());
         dispatch(homeActions.notificateIsCopied());
         setTimeout(
             () => dispatch(homeActions.closeIsCopiedNotification()),

--- a/src/Hooks/useInput.ts
+++ b/src/Hooks/useInput.ts
@@ -1,0 +1,33 @@
+import { ChangeEvent, useState } from "react";
+
+const useInput = (
+    initialValue: string,
+    onBlurValidator?: (value: string) => boolean,
+) => {
+    const [value, setValue] = useState(initialValue);
+    const [isValid, setIsValid] = useState<boolean | null>(null);
+
+    const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const {
+            target: { value },
+        } = event;
+        if (onBlurValidator) {
+            setIsValid(null);
+        }
+        setValue(value);
+    };
+
+    const resetValue = () => setValue("");
+
+    const onBlur = () => {
+        if (onBlurValidator) {
+            setIsValid(onBlurValidator(value));
+        }
+    };
+
+    return onBlurValidator
+        ? [resetValue, isValid, { value, onChange, onBlur }]
+        : [resetValue, { value, onChange }];
+};
+
+export default useInput;

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -7,6 +7,8 @@ import Header from "components/Common/Header";
 
 import { useAppSelector } from "app/store/hooks";
 
+export const token =
+    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTY0MzEyNDE4N30.1cDekafQGl7dLdfaPs8YciAOM_f9rhAesVJvvoOpdLfWBc3FHAgE_mZEMeRQyxOUXB6mHhybXrB0kZjYx9VDmA";
 const Routes = () => {
     return (
         <BrowserRouter>

--- a/src/app/store/ducks/home/homThunk.ts
+++ b/src/app/store/ducks/home/homThunk.ts
@@ -52,22 +52,3 @@ export const getExtraArticle = createAsyncThunk<
         throw ThunkOptions.rejectWithValue(error);
     }
 });
-
-export const getMiniProfile = createAsyncThunk<
-    any,
-    { token: string; username: string }
->("home/getMiniProfile", async (payload, ThunkOptions) => {
-    const config = {
-        headers: { Authorization: `Bearer ${payload.token}` },
-    };
-    try {
-        const data = await axios.get(
-            `${BASE_URL}/accounts/${payload.username}/mini`,
-            config,
-        );
-        console.log(data);
-        return data;
-    } catch (error) {
-        throw ThunkOptions.rejectWithValue(error);
-    }
-});

--- a/src/app/store/ducks/home/homThunk.ts
+++ b/src/app/store/ducks/home/homThunk.ts
@@ -40,7 +40,6 @@ export const getExtraArticle = createAsyncThunk<
                 data: { content: data, empty },
             },
         } = await axios.get(`${BASE_URL}/posts?page=${payload.page}`, config); // 단건 조회 api 추가
-        console.log(empty);
         if (empty) {
             throw ThunkOptions.rejectWithValue(
                 "게시물이 더 이상 존재하지 않습니다.",

--- a/src/app/store/ducks/home/homThunk.ts
+++ b/src/app/store/ducks/home/homThunk.ts
@@ -87,9 +87,8 @@ export const postUnfollow = createAsyncThunk<
     try {
         const {
             data: { data },
-        } = await axios.post(
-            `${BASE_URL}/${payload.username}/unfollow`,
-            null,
+        } = await axios.delete(
+            `${BASE_URL}/${payload.username}/follow`,
             config,
         );
         return data;

--- a/src/app/store/ducks/home/homThunk.ts
+++ b/src/app/store/ducks/home/homThunk.ts
@@ -1,5 +1,4 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import { HomeType } from "@type";
 import { homeActions } from "app/store/ducks/home/homeSlice";
 import axios from "axios";
 

--- a/src/app/store/ducks/home/homThunk.ts
+++ b/src/app/store/ducks/home/homThunk.ts
@@ -1,12 +1,16 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { homeActions } from "app/store/ducks/home/homeSlice";
+import {
+    ExtraArticleProps,
+    RecentArticlesProps,
+} from "app/store/ducks/home/homeThunk.type";
 import axios from "axios";
 
 const BASE_URL =
     "http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080";
 
 export const getHomeArticles = createAsyncThunk<
-    HomeType.ArticleProps[],
+    HomeType.ArticleStateProps[],
     {
         token: string;
     }
@@ -17,15 +21,25 @@ export const getHomeArticles = createAsyncThunk<
     try {
         const {
             data: { data },
-        } = await axios.get(`${BASE_URL}/posts/recent`, config);
-        return data;
+        }: RecentArticlesProps = await axios.get(
+            `${BASE_URL}/posts/recent`,
+            config,
+        );
+        const articlesState: HomeType.ArticleStateProps[] = data.map(
+            (article) => ({
+                ...article,
+                isFollowing: true,
+                followLoading: false,
+            }),
+        );
+        return articlesState;
     } catch (error) {
         throw ThunkOptions.rejectWithValue(error);
     }
 });
 
 export const getExtraArticle = createAsyncThunk<
-    HomeType.ArticleProps,
+    HomeType.ArticleStateProps,
     {
         token: string;
         page: number;
@@ -39,14 +53,70 @@ export const getExtraArticle = createAsyncThunk<
             data: {
                 data: { content: data, empty },
             },
-        } = await axios.get(`${BASE_URL}/posts?page=${payload.page}`, config); // 단건 조회 api 추가
+        }: ExtraArticleProps = await axios.get(
+            `${BASE_URL}/posts?page=${payload.page}`,
+            config,
+        ); // 단건 조회 api 추가
         if (empty) {
             throw ThunkOptions.rejectWithValue(
                 "게시물이 더 이상 존재하지 않습니다.",
             );
         }
         ThunkOptions.dispatch(homeActions.increaseExtraArticlesCount());
-        return data[0];
+        const articleState: HomeType.ArticleStateProps = {
+            ...data[0],
+            isFollowing: true,
+            followLoading: false,
+        };
+        return articleState;
+    } catch (error) {
+        throw ThunkOptions.rejectWithValue(error);
+    }
+});
+
+export const postUnfollow = createAsyncThunk<
+    string, // 이후 데이터 보고 수정
+    {
+        token: string;
+        username: string;
+    }
+>("home/postUnfollow", async (payload, ThunkOptions) => {
+    const config = {
+        headers: { Authorization: `Bearer ${payload.token}` },
+    };
+    try {
+        const {
+            data: { data },
+        } = await axios.post(
+            `${BASE_URL}/${payload.username}/unfollow`,
+            null,
+            config,
+        );
+        return data;
+    } catch (error) {
+        throw ThunkOptions.rejectWithValue(error);
+    }
+});
+
+export const postFollow = createAsyncThunk<
+    string, // 이후 데이터 보고 수정
+    {
+        token: string;
+        username: string;
+    }
+>("home/postFollow", async (payload, ThunkOptions) => {
+    const config = {
+        headers: { Authorization: `Bearer ${payload.token}` },
+    };
+    try {
+        const {
+            data: { data },
+        } = await axios.post(
+            `${BASE_URL}/${payload.username}/follow`,
+            null,
+            config,
+        );
+        return data;
     } catch (error) {
         throw ThunkOptions.rejectWithValue(error);
     }

--- a/src/app/store/ducks/home/homThunk.ts
+++ b/src/app/store/ducks/home/homThunk.ts
@@ -3,6 +3,9 @@ import { HomeType } from "@type";
 import { homeActions } from "app/store/ducks/home/homeSlice";
 import axios from "axios";
 
+const BASE_URL =
+    "http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080";
+
 export const getHomeArticles = createAsyncThunk<
     HomeType.ArticleProps[],
     {
@@ -15,10 +18,7 @@ export const getHomeArticles = createAsyncThunk<
     try {
         const {
             data: { data },
-        } = await axios.get(
-            "http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080/posts/recent",
-            config,
-        );
+        } = await axios.get(`${BASE_URL}/posts/recent`, config);
         return data;
     } catch (error) {
         throw ThunkOptions.rejectWithValue(error);
@@ -40,10 +40,7 @@ export const getExtraArticle = createAsyncThunk<
             data: {
                 data: { content: data, empty },
             },
-        } = await axios.get(
-            `http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080/posts?page=${payload.page}`,
-            config,
-        ); // 단건 조회 api 추가
+        } = await axios.get(`${BASE_URL}/posts?page=${payload.page}`, config); // 단건 조회 api 추가
         console.log(empty);
         if (empty) {
             throw ThunkOptions.rejectWithValue(
@@ -66,9 +63,10 @@ export const getMiniProfile = createAsyncThunk<
     };
     try {
         const data = await axios.get(
-            `http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080/accounts/${payload.username}/mini`,
+            `${BASE_URL}/accounts/${payload.username}/mini`,
             config,
         );
+        console.log(data);
         return data;
     } catch (error) {
         throw ThunkOptions.rejectWithValue(error);

--- a/src/app/store/ducks/home/homThunk.ts
+++ b/src/app/store/ducks/home/homThunk.ts
@@ -56,3 +56,21 @@ export const getExtraArticle = createAsyncThunk<
         throw ThunkOptions.rejectWithValue(error);
     }
 });
+
+export const getMiniProfile = createAsyncThunk<
+    any,
+    { token: string; username: string }
+>("home/getMiniProfile", async (payload, ThunkOptions) => {
+    const config = {
+        headers: { Authorization: `Bearer ${payload.token}` },
+    };
+    try {
+        const data = await axios.get(
+            `http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080/accounts/${payload.username}/mini`,
+            config,
+        );
+        return data;
+    } catch (error) {
+        throw ThunkOptions.rejectWithValue(error);
+    }
+});

--- a/src/app/store/ducks/home/homeSlice.ts
+++ b/src/app/store/ducks/home/homeSlice.ts
@@ -593,13 +593,13 @@ const initialState: HomeType.homeStateProps = {
     isAsyncError: false,
     hoveredUser: null,
     isCopiedNotification: false,
-    modalDTOs: {
-        activatedModal: null,
-        memberNickname: undefined,
-        memberImageUrl: undefined,
-        modalPosition: undefined,
-        postId: undefined,
-    },
+    // modalDTOs: {
+    //     activatedModal: null,
+    //     memberNickname: undefined,
+    //     memberImageUrl: undefined,
+    //     modalPosition: undefined,
+    //     postId: undefined,
+    // },
 };
 
 const homeSlice = createSlice({
@@ -618,20 +618,20 @@ const homeSlice = createSlice({
         ) => {
             state.storiesScrollPosition = action.payload;
         },
-        startModal: (state, action: PayloadAction<HomeType.ModalDTOsProps>) => {
-            state.modalDTOs = {
-                ...state.modalDTOs,
-                ...action.payload,
-            }; // 전달한 modalDTO 값만 변경
-        },
-        resetModal: (state) => {
-            state.modalDTOs = {
-                activatedModal: null,
-                memberNickname: undefined,
-                modalPosition: undefined,
-                postId: undefined,
-            };
-        },
+        // startModal: (state, action: PayloadAction<HomeType.ModalDTOsProps>) => {
+        //     state.modalDTOs = {
+        //         ...state.modalDTOs,
+        //         ...action.payload,
+        //     }; // 전달한 modalDTO 값만 변경
+        // },
+        // resetModal: (state) => {
+        //     state.modalDTOs = {
+        //         activatedModal: null,
+        //         memberNickname: undefined,
+        //         modalPosition: undefined,
+        //         postId: undefined,
+        //     };
+        // },
         increaseExtraArticlesCount: (state) => {
             state.extraArticlesCount++;
         },
@@ -642,13 +642,10 @@ const homeSlice = createSlice({
                 state.isLoading = true;
                 state.isAsyncError = false;
             })
-            .addCase(
-                getHomeArticles.fulfilled,
-                (state, action: PayloadAction<HomeType.ArticleProps[]>) => {
-                    state.articles = action.payload;
-                    state.isLoading = false;
-                },
-            )
+            .addCase(getHomeArticles.fulfilled, (state, action) => {
+                state.articles = action.payload;
+                state.isLoading = false;
+            })
             .addCase(getHomeArticles.rejected, (state) => {
                 state.isLoading = false;
                 state.isAsyncError = true;

--- a/src/app/store/ducks/home/homeSlice.ts
+++ b/src/app/store/ducks/home/homeSlice.ts
@@ -2,10 +2,14 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import {
     getExtraArticle,
     getHomeArticles,
+    postFollow,
+    postUnfollow,
 } from "app/store/ducks/home/homThunk";
 
-const DUMMY_ARTICLES: HomeType.ArticleProps[] = [
+const DUMMY_ARTICLES: HomeType.ArticleStateProps[] = [
     {
+        followLoading: false,
+        isFollowing: true,
         postId: 10,
         followingMemberUsernameLikedPost: null,
         memberImageUrl:
@@ -88,6 +92,8 @@ const DUMMY_ARTICLES: HomeType.ArticleProps[] = [
         postUploadDate: "2022-01-03T13:33:00",
     },
     {
+        followLoading: false,
+        isFollowing: true,
         postId: 11,
         followingMemberUsernameLikedPost: "followingUser",
         memberImageUrl:
@@ -170,6 +176,8 @@ const DUMMY_ARTICLES: HomeType.ArticleProps[] = [
         postUploadDate: "2022-01-03T13:33:00",
     },
     {
+        followLoading: false,
+        isFollowing: true,
         postId: 12,
         followingMemberUsernameLikedPost: null,
         memberImageUrl:
@@ -252,6 +260,8 @@ const DUMMY_ARTICLES: HomeType.ArticleProps[] = [
         postUploadDate: "2022-01-03T13:33:00",
     },
     {
+        followLoading: false,
+        isFollowing: true,
         postId: 13,
         followingMemberUsernameLikedPost: null,
         memberImageUrl:
@@ -334,6 +344,8 @@ const DUMMY_ARTICLES: HomeType.ArticleProps[] = [
         postUploadDate: "2022-01-03T13:33:00",
     },
     {
+        followLoading: false,
+        isFollowing: true,
         postId: 14,
         followingMemberUsernameLikedPost: null,
         memberImageUrl:
@@ -416,6 +428,8 @@ const DUMMY_ARTICLES: HomeType.ArticleProps[] = [
         postUploadDate: "2022-01-03T13:33:00",
     },
     {
+        followLoading: false,
+        isFollowing: true,
         postId: 15,
         followingMemberUsernameLikedPost: null,
         memberImageUrl:
@@ -556,6 +570,52 @@ const homeSlice = createSlice({
             .addCase(getExtraArticle.rejected, (state, action) => {
                 state.isExtraArticleLoading = false;
                 state.isAsyncError = true;
+            })
+            .addCase(postUnfollow.pending, (state, action) => {
+                state.articles.forEach((article) => {
+                    if (article.memberUsername === action.meta.arg.username) {
+                        // article.followLoading = true;
+                    }
+                });
+            })
+            .addCase(postUnfollow.fulfilled, (state, action) => {
+                state.articles.forEach((article) => {
+                    if (article.memberUsername === action.meta.arg.username) {
+                        // article.followLoading = false;
+                        article.isFollowing = false;
+                    }
+                });
+            })
+            .addCase(postUnfollow.rejected, (state, action) => {
+                state.articles.forEach((article) => {
+                    if (article.memberUsername === action.meta.arg.username) {
+                        // article.followLoading = false;
+                        article.isFollowing = true;
+                    }
+                });
+            })
+            .addCase(postFollow.pending, (state, action) => {
+                state.articles.forEach((article) => {
+                    if (article.memberUsername === action.meta.arg.username) {
+                        article.followLoading = true;
+                    }
+                });
+            })
+            .addCase(postFollow.fulfilled, (state, action) => {
+                state.articles.forEach((article) => {
+                    if (article.memberUsername === action.meta.arg.username) {
+                        article.followLoading = false;
+                        article.isFollowing = true;
+                    }
+                });
+            })
+            .addCase(postFollow.rejected, (state, action) => {
+                state.articles.forEach((article) => {
+                    if (article.memberUsername === action.meta.arg.username) {
+                        article.followLoading = false;
+                        article.isFollowing = false;
+                    }
+                });
             });
     },
 });

--- a/src/app/store/ducks/home/homeSlice.ts
+++ b/src/app/store/ducks/home/homeSlice.ts
@@ -594,9 +594,12 @@ const initialState: HomeType.homeStateProps = {
     isAsyncError: false,
     hoveredUser: null,
     isCopiedNotification: false,
-    homeModal: {
+    modalDTOs: {
         activatedModal: null,
-        handledObj: null,
+        memberNickname: undefined,
+        memberImageUrl: undefined,
+        modalPosition: undefined,
+        postId: undefined,
     },
 };
 
@@ -616,14 +619,18 @@ const homeSlice = createSlice({
         ) => {
             state.storiesScrollPosition = action.payload;
         },
-        startModal: (state, action: PayloadAction<HomeType.homeModalProps>) => {
-            state.homeModal = action.payload;
-            // 비동기적으로 데이터를 가져옴
+        startModal: (state, action: PayloadAction<HomeType.ModalDTOsProps>) => {
+            state.modalDTOs = {
+                ...state.modalDTOs,
+                ...action.payload,
+            }; // 전달한 modalDTO 값만 변경
         },
         resetModal: (state) => {
-            state.homeModal = {
+            state.modalDTOs = {
                 activatedModal: null,
-                handledObj: null,
+                memberNickname: undefined,
+                modalPosition: undefined,
+                postId: undefined,
             };
         },
         increaseExtraArticlesCount: (state) => {

--- a/src/app/store/ducks/home/homeSlice.ts
+++ b/src/app/store/ducks/home/homeSlice.ts
@@ -499,107 +499,15 @@ const DUMMY_ARTICLES: HomeType.ArticleProps[] = [
     },
 ];
 
-const EXTRA_ARTICLES: HomeType.ArticleProps = {
-    postId: 102,
-    followingMemberUsernameLikedPost: null,
-    memberImageUrl:
-        "https://images.unsplash.com/photo-1497316730643-415fac54a2af?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2000&q=80",
-    memberNickname: "spursofficial",
-    memberUsername: "Tottenham Hotspur",
-    postBookmarkFlag: false,
-    postCommentsCount: 0,
-    postContent: `이 영역은 토트넘 핫스퍼 공식 계정 글입니다.
-이 영역은 토트넘 핫스퍼 공식 계정 글입니다.
-이 영역은 토트넘 핫스퍼 공식 계정 글입니다.`,
-    postImageDTOs: [
-        {
-            id: 12,
-            postImageUrl:
-                "https://images.unsplash.com/photo-1497316730643-415fac54a2af?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2000&q=80",
-
-            postTagDTOs: [
-                {
-                    id: 12,
-                    tag: {
-                        username: "dummyUsername",
-                        x: 30,
-                        y: 40,
-                    },
-                },
-                {
-                    id: 13,
-                    tag: {
-                        username: "dummyUsername",
-                        x: 60,
-                        y: 60,
-                    },
-                },
-            ],
-        },
-        {
-            id: 13,
-            postImageUrl:
-                "https://images.unsplash.com/photo-1497316730643-415fac54a2af?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2000&q=80",
-
-            postTagDTOs: [
-                {
-                    id: 12,
-                    tag: {
-                        username: "dummyUsername",
-                        x: 60,
-                        y: 70,
-                    },
-                },
-            ],
-        },
-        {
-            id: 14,
-            postImageUrl:
-                "https://images.unsplash.com/photo-1497316730643-415fac54a2af?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2000&q=80",
-            postTagDTOs: [
-                {
-                    id: 12,
-                    tag: {
-                        username: "dummyUsername",
-                        x: 30,
-                        y: 40,
-                    },
-                },
-                {
-                    id: 13,
-                    tag: {
-                        username: "dummyUsername",
-                        x: 60,
-                        y: 60,
-                    },
-                },
-            ],
-        },
-    ],
-    postLikeFlag: true,
-    postLikesCount: 24,
-    postUploadDate: "2022-01-03T13:33:00",
-};
-
-// 좋아요 여부를 따로? 아니면 내가 필터링?
-// 좋아요 수를 따로? 아니면 내가 arr 길이 계산?
-
 const initialState: HomeType.homeStateProps = {
     storiesScrollPosition: "left",
     articles: [],
-    isLoading: true, /// dummy
+    isLoading: true,
     isExtraArticleLoading: false,
     extraArticlesCount: 0,
     isAsyncError: false,
     hoveredUser: null,
     isCopiedNotification: false,
-    // modalDTOs: {
-    //     activatedModal: null,
-    //     memberNickname: undefined,
-    //     memberImageUrl: undefined,
-    //     modalPosition: undefined,
-    //     postId: undefined,
-    // },
 };
 
 const homeSlice = createSlice({
@@ -618,20 +526,6 @@ const homeSlice = createSlice({
         ) => {
             state.storiesScrollPosition = action.payload;
         },
-        // startModal: (state, action: PayloadAction<HomeType.ModalDTOsProps>) => {
-        //     state.modalDTOs = {
-        //         ...state.modalDTOs,
-        //         ...action.payload,
-        //     }; // 전달한 modalDTO 값만 변경
-        // },
-        // resetModal: (state) => {
-        //     state.modalDTOs = {
-        //         activatedModal: null,
-        //         memberNickname: undefined,
-        //         modalPosition: undefined,
-        //         postId: undefined,
-        //     };
-        // },
         increaseExtraArticlesCount: (state) => {
             state.extraArticlesCount++;
         },

--- a/src/app/store/ducks/home/homeSlice.ts
+++ b/src/app/store/ducks/home/homeSlice.ts
@@ -1,5 +1,4 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { HomeType } from "@type";
 import {
     getExtraArticle,
     getHomeArticles,

--- a/src/app/store/ducks/home/homeSlice.ts
+++ b/src/app/store/ducks/home/homeSlice.ts
@@ -571,17 +571,9 @@ const homeSlice = createSlice({
                 state.isExtraArticleLoading = false;
                 state.isAsyncError = true;
             })
-            .addCase(postUnfollow.pending, (state, action) => {
-                state.articles.forEach((article) => {
-                    if (article.memberUsername === action.meta.arg.username) {
-                        // article.followLoading = true;
-                    }
-                });
-            })
             .addCase(postUnfollow.fulfilled, (state, action) => {
                 state.articles.forEach((article) => {
                     if (article.memberUsername === action.meta.arg.username) {
-                        // article.followLoading = false;
                         article.isFollowing = false;
                     }
                 });
@@ -589,7 +581,6 @@ const homeSlice = createSlice({
             .addCase(postUnfollow.rejected, (state, action) => {
                 state.articles.forEach((article) => {
                     if (article.memberUsername === action.meta.arg.username) {
-                        // article.followLoading = false;
                         article.isFollowing = true;
                     }
                 });

--- a/src/app/store/ducks/home/homeThunk.type.ts
+++ b/src/app/store/ducks/home/homeThunk.type.ts
@@ -1,0 +1,15 @@
+// fetched data type
+export interface RecentArticlesProps {
+    data: {
+        data: HomeType.ArticleProps[];
+    };
+}
+
+export interface ExtraArticleProps {
+    data: {
+        data: {
+            content: [HomeType.ArticleProps];
+            empty: boolean;
+        };
+    };
+}

--- a/src/app/store/ducks/modal/modalSlice.ts
+++ b/src/app/store/ducks/modal/modalSlice.ts
@@ -1,18 +1,23 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { getMiniProfile } from "app/store/ducks/modal/modalThunk";
 
 const initialState: ModalType.ModalStateProps = {
     activatedModal: null,
-    memberNickname: undefined,
+    memberUsername: undefined,
     memberImageUrl: undefined,
     modalPosition: undefined,
     postId: undefined,
+    miniProfile: undefined,
 };
 
 const modalSlice = createSlice({
     name: "modal",
     initialState,
     reducers: {
-        startModal: (state, action) => {
+        startModal: (
+            state,
+            action: PayloadAction<ModalType.ModalStateProps>,
+        ) => {
             return {
                 ...state,
                 ...action.payload,
@@ -21,11 +26,20 @@ const modalSlice = createSlice({
         resetModal: (state) => {
             return {
                 activatedModal: null,
-                memberNickname: undefined,
+                memberUsername: undefined,
                 modalPosition: undefined,
                 postId: undefined,
+                miniProfile: undefined,
             };
         },
+    },
+    extraReducers: (build) => {
+        build
+            .addCase(getMiniProfile.pending, (state, payload) => {})
+            .addCase(getMiniProfile.fulfilled, (state, action) => {
+                state.miniProfile = action.payload;
+            })
+            .addCase(getMiniProfile.rejected, (state, action) => {});
     },
 });
 

--- a/src/app/store/ducks/modal/modalSlice.ts
+++ b/src/app/store/ducks/modal/modalSlice.ts
@@ -3,11 +3,13 @@ import { getMiniProfile } from "app/store/ducks/modal/modalThunk";
 
 const initialState: ModalType.ModalStateProps = {
     activatedModal: null,
-    memberUsername: undefined,
-    memberImageUrl: undefined,
+    memberUsername: "",
+    memberImageUrl: "",
+    memberNickname: "",
     modalPosition: undefined,
     postId: undefined,
     miniProfile: undefined,
+    isOnMiniProfile: false,
 };
 
 const modalSlice = createSlice({
@@ -23,23 +25,69 @@ const modalSlice = createSlice({
                 ...action.payload,
             }; // 전달한 modalDTO 값만 변경
         },
+        changeActivatedModal: (
+            state,
+            action: PayloadAction<ModalType.ActivatedModalType>,
+        ) => {
+            state.activatedModal = action.payload;
+        },
+        mouseOnHoverModal: (state) => {
+            state.isOnMiniProfile = true;
+        },
+        mouseNotOnHoverModal: (state) => {
+            state.isOnMiniProfile = false;
+        },
+        maintainModalon: (
+            state,
+            action: PayloadAction<ModalType.ActivatedModalType>,
+        ) => {
+            if (action.payload === "unfollowing" && state.isOnMiniProfile) {
+                state.isOnMiniProfile = true;
+                state.activatedModal = "unfollowing";
+            } else {
+                state.activatedModal = action.payload;
+            }
+        },
         resetModal: (state) => {
-            return {
-                activatedModal: null,
-                memberUsername: undefined,
-                modalPosition: undefined,
-                postId: undefined,
-                miniProfile: undefined,
-            };
+            return initialState;
+        },
+        checkMouseOnHoverModal: (state) => {
+            if (
+                !state.isOnMiniProfile &&
+                state.activatedModal !== "unfollowing" // hover에서 팔로잉 클릭해서 언팔로우 모달이 켜질 경우 유지
+            ) {
+                return {
+                    activatedModal: null,
+                    memberUsername: "",
+                    memberImageUrl: "",
+                    memberNickname: "",
+                    modalPosition: undefined,
+                    postId: undefined,
+                    miniProfile: undefined,
+                    isOnMiniProfile: false,
+                };
+            } else {
+                return state;
+            }
+        },
+        changeHoverModalPosition: (
+            state,
+            action: PayloadAction<ModalType.ModalPositionProps>,
+        ) => {
+            state.modalPosition = action.payload;
         },
     },
     extraReducers: (build) => {
         build
-            .addCase(getMiniProfile.pending, (state, payload) => {})
+            .addCase(getMiniProfile.pending, (state) => {
+                state.miniProfile = undefined;
+            })
             .addCase(getMiniProfile.fulfilled, (state, action) => {
                 state.miniProfile = action.payload;
-            })
-            .addCase(getMiniProfile.rejected, (state, action) => {});
+            });
+        // .addCase(getMiniProfile.rejected, (state, action) => {
+
+        // });
     },
 });
 

--- a/src/app/store/ducks/modal/modalSlice.ts
+++ b/src/app/store/ducks/modal/modalSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { postFollow, postUnfollow } from "app/store/ducks/home/homThunk";
 import { getMiniProfile } from "app/store/ducks/modal/modalThunk";
 
 const initialState: ModalType.ModalStateProps = {
@@ -75,10 +76,48 @@ const modalSlice = createSlice({
             })
             .addCase(getMiniProfile.fulfilled, (state, action) => {
                 state.miniProfile = action.payload;
-            });
-        // .addCase(getMiniProfile.rejected, (state, action) => {
+            })
+            // .addCase(getMiniProfile.rejected, (state, action) => {
 
-        // });
+            // });
+            .addCase(postUnfollow.pending, (state) => {
+                if (state.miniProfile) {
+                    state.miniProfile.isLoading = true;
+                    state.isOnMiniProfile = true; // 로딩동안 미니프로필 유지
+                    state.activatedModal = null;
+                }
+            })
+            .addCase(postUnfollow.fulfilled, (state) => {
+                if (state.miniProfile) {
+                    state.miniProfile.isLoading = false;
+                    state.miniProfile.following = false;
+                }
+            })
+            .addCase(postUnfollow.rejected, (state) => {
+                if (state.miniProfile) {
+                    state.miniProfile.isLoading = false;
+                    state.miniProfile.following = true;
+                }
+            })
+            .addCase(postFollow.pending, (state) => {
+                if (state.miniProfile) {
+                    state.miniProfile.isLoading = true;
+                    state.isOnMiniProfile = true; // 로딩동안 미니프로필 유지
+                    state.activatedModal = null;
+                }
+            })
+            .addCase(postFollow.fulfilled, (state) => {
+                if (state.miniProfile) {
+                    state.miniProfile.isLoading = false;
+                    state.miniProfile.following = true;
+                }
+            })
+            .addCase(postFollow.rejected, (state) => {
+                if (state.miniProfile) {
+                    state.miniProfile.isLoading = false;
+                    state.miniProfile.following = false;
+                }
+            });
     },
 });
 

--- a/src/app/store/ducks/modal/modalSlice.ts
+++ b/src/app/store/ducks/modal/modalSlice.ts
@@ -56,16 +56,7 @@ const modalSlice = createSlice({
                 !state.isOnMiniProfile &&
                 state.activatedModal !== "unfollowing" // hover에서 팔로잉 클릭해서 언팔로우 모달이 켜질 경우 유지
             ) {
-                return {
-                    activatedModal: null,
-                    memberUsername: "",
-                    memberImageUrl: "",
-                    memberNickname: "",
-                    modalPosition: undefined,
-                    postId: undefined,
-                    miniProfile: undefined,
-                    isOnMiniProfile: false,
-                };
+                return initialState;
             } else {
                 return state;
             }

--- a/src/app/store/ducks/modal/modalSlice.ts
+++ b/src/app/store/ducks/modal/modalSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState: ModalType.ModalStateProps = {
+    activatedModal: null,
+    memberNickname: undefined,
+    memberImageUrl: undefined,
+    modalPosition: undefined,
+    postId: undefined,
+};
+
+const modalSlice = createSlice({
+    name: "modal",
+    initialState,
+    reducers: {
+        startModal: (state, action) => {
+            return {
+                ...state,
+                ...action.payload,
+            }; // 전달한 modalDTO 값만 변경
+        },
+        resetModal: (state) => {
+            return {
+                activatedModal: null,
+                memberNickname: undefined,
+                modalPosition: undefined,
+                postId: undefined,
+            };
+        },
+    },
+});
+
+export const modalReducer = modalSlice.reducer;
+
+export const modalActions = modalSlice.actions;

--- a/src/app/store/ducks/modal/modalSlice.ts
+++ b/src/app/store/ducks/modal/modalSlice.ts
@@ -7,7 +7,6 @@ const initialState: ModalType.ModalStateProps = {
     memberUsername: "",
     memberImageUrl: "",
     memberNickname: "",
-    modalPosition: undefined,
     postId: undefined,
     miniProfile: undefined,
     isOnMiniProfile: false,
@@ -66,7 +65,9 @@ const modalSlice = createSlice({
             state,
             action: PayloadAction<ModalType.ModalPositionProps>,
         ) => {
-            state.modalPosition = action.payload;
+            if (state.miniProfile) {
+                state.miniProfile.modalPosition = action.payload;
+            }
         },
     },
     extraReducers: (build) => {

--- a/src/app/store/ducks/modal/modalThunk.ts
+++ b/src/app/store/ducks/modal/modalThunk.ts
@@ -18,21 +18,6 @@ export const getMiniProfile = createAsyncThunk<
             `${BASE_URL}/accounts/${payload.memberUsername}/mini`,
             config,
         );
-        // blocked: false
-        // blocking: false
-        // follower: false
-        // following: true
-        // followingMemberFollow: "dlwlrma2"
-        // me: false // 나인 경우 아래 버튼 링크가 "프로필 편짐"으로 떠야 함
-        // memberFollowersCount: 2
-        // memberFollowingsCount: 0
-        // memberImage: {imageUrl: 'https://bluetifulc-spring-bucket.s3.ap-northeast-2.amazonaws.com/member/base-UUID_base.PNG', imageType: 'PNG', imageName: 'base', imageUUID: 'base-UUID'}
-        // memberName: "이지금"
-        // memberPosts: (3) [{…}, {…}, {…}]
-        // memberPostsCount: 15
-        // memberUsername: "dlwlrma1"
-        // memberWebsite: null
-        console.log(data);
         return data;
     } catch (error) {
         throw ThunkOptions.rejectWithValue(error);

--- a/src/app/store/ducks/modal/modalThunk.ts
+++ b/src/app/store/ducks/modal/modalThunk.ts
@@ -5,7 +5,7 @@ const BASE_URL =
     "http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080";
 
 export const getMiniProfile = createAsyncThunk<
-    ModalType.MiniProfileProps,
+    ModalType.MiniProfileStateProps,
     { token: string; memberUsername: string }
 >("modal/getMiniProfile", async (payload, ThunkOptions) => {
     const config = {
@@ -18,7 +18,7 @@ export const getMiniProfile = createAsyncThunk<
             `${BASE_URL}/accounts/${payload.memberUsername}/mini`,
             config,
         );
-        return data;
+        return { ...data, isLoading: false };
     } catch (error) {
         throw ThunkOptions.rejectWithValue(error);
     }

--- a/src/app/store/ducks/modal/modalThunk.ts
+++ b/src/app/store/ducks/modal/modalThunk.ts
@@ -6,7 +6,11 @@ const BASE_URL =
 
 export const getMiniProfile = createAsyncThunk<
     ModalType.MiniProfileStateProps,
-    { token: string; memberUsername: string }
+    {
+        token: string;
+        memberUsername: string;
+        modalPosition: ModalType.ModalPositionProps;
+    }
 >("modal/getMiniProfile", async (payload, ThunkOptions) => {
     const config = {
         headers: { Authorization: `Bearer ${payload.token}` },
@@ -18,7 +22,11 @@ export const getMiniProfile = createAsyncThunk<
             `${BASE_URL}/accounts/${payload.memberUsername}/mini`,
             config,
         );
-        return { ...data, isLoading: false };
+        return {
+            ...data,
+            isLoading: false,
+            modalPosition: payload.modalPosition,
+        };
     } catch (error) {
         throw ThunkOptions.rejectWithValue(error);
     }

--- a/src/app/store/ducks/modal/modalThunk.ts
+++ b/src/app/store/ducks/modal/modalThunk.ts
@@ -1,0 +1,40 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
+
+const BASE_URL =
+    "http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080";
+
+export const getMiniProfile = createAsyncThunk<
+    ModalType.MiniProfileProps,
+    { token: string; memberUsername: string }
+>("modal/getMiniProfile", async (payload, ThunkOptions) => {
+    const config = {
+        headers: { Authorization: `Bearer ${payload.token}` },
+    };
+    try {
+        const {
+            data: { data },
+        } = await axios.get(
+            `${BASE_URL}/accounts/${payload.memberUsername}/mini`,
+            config,
+        );
+        // blocked: false
+        // blocking: false
+        // follower: false
+        // following: true
+        // followingMemberFollow: "dlwlrma2"
+        // me: false // 나인 경우 아래 버튼 링크가 "프로필 편짐"으로 떠야 함
+        // memberFollowersCount: 2
+        // memberFollowingsCount: 0
+        // memberImage: {imageUrl: 'https://bluetifulc-spring-bucket.s3.ap-northeast-2.amazonaws.com/member/base-UUID_base.PNG', imageType: 'PNG', imageName: 'base', imageUUID: 'base-UUID'}
+        // memberName: "이지금"
+        // memberPosts: (3) [{…}, {…}, {…}]
+        // memberPostsCount: 15
+        // memberUsername: "dlwlrma1"
+        // memberWebsite: null
+        console.log(data);
+        return data;
+    } catch (error) {
+        throw ThunkOptions.rejectWithValue(error);
+    }
+});

--- a/src/app/store/store.ts
+++ b/src/app/store/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { homeReducer } from "app/store/ducks/home/homeSlice";
+import { modalReducer } from "app/store/ducks/modal/modalSlice";
 import authSlice from "features/Auth/authSlice";
 
 export const store = configureStore({
     reducer: {
         // auth: authSlice,
         home: homeReducer,
+        modal: modalReducer,
     },
 });
 

--- a/src/app/store/store.ts
+++ b/src/app/store/store.ts
@@ -1,11 +1,9 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { homeReducer } from "app/store/ducks/home/homeSlice";
 import { modalReducer } from "app/store/ducks/modal/modalSlice";
-import authSlice from "features/Auth/authSlice";
 
 export const store = configureStore({
     reducer: {
-        // auth: authSlice,
         home: homeReducer,
         modal: modalReducer,
     },

--- a/src/assets/Svgs/loadingCircle.svg
+++ b/src/assets/Svgs/loadingCircle.svg
@@ -5,7 +5,7 @@
     height="current"
 >
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0"
         rx="3"
@@ -16,7 +16,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.08333333333333333"
         rx="3"
@@ -27,7 +27,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.16666666666666666"
         rx="3"
@@ -38,7 +38,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.25"
         rx="3"
@@ -49,7 +49,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.3333333333333333"
         rx="3"
@@ -60,7 +60,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.4166666666666667"
         rx="3"
@@ -71,7 +71,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.5"
         rx="3"
@@ -82,7 +82,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.5833333333333334"
         rx="3"
@@ -93,7 +93,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.6666666666666666"
         rx="3"
@@ -104,7 +104,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.75"
         rx="3"
@@ -115,7 +115,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.8333333333333334"
         rx="3"
@@ -126,7 +126,7 @@
         y="47"
     ></rect>
     <rect
-        fill="#555555"
+        fill="current"
         height="6"
         opacity="0.9166666666666666"
         rx="3"

--- a/src/components/Common/Loading.tsx
+++ b/src/components/Common/Loading.tsx
@@ -44,16 +44,16 @@ const StyledLoading = styled.div`
 
 interface LoadingProps {
     size: number;
-    isInButtun?: boolean;
+    isInButton?: boolean;
 }
 
-const Loading = ({ size, isInButtun = false }: LoadingProps) => {
+const Loading = ({ size, isInButton = false }: LoadingProps) => {
     return (
         <StyledLoading>
             <LoadingCircle
                 width={size}
                 height={size}
-                fill={isInButtun ? "#fff" : "#555555"}
+                fill={isInButton ? "#fff" : "#555555"}
             />
         </StyledLoading>
     );

--- a/src/components/Common/Loading.tsx
+++ b/src/components/Common/Loading.tsx
@@ -44,12 +44,17 @@ const StyledLoading = styled.div`
 
 interface LoadingProps {
     size: number;
+    isInButtun?: boolean;
 }
 
-const Loading = ({ size }: LoadingProps) => {
+const Loading = ({ size, isInButtun = false }: LoadingProps) => {
     return (
         <StyledLoading>
-            <LoadingCircle width={size} height={size} />
+            <LoadingCircle
+                width={size}
+                height={size}
+                fill={isInButtun ? "#fff" : "#555555"}
+            />
         </StyledLoading>
     );
 };

--- a/src/components/Common/StoryCircle.tsx
+++ b/src/components/Common/StoryCircle.tsx
@@ -62,11 +62,11 @@ interface StoryCircleProps {
     username: string;
     scale: number;
     onMouseEnter?: (
-        event:
-            | React.MouseEvent<HTMLSpanElement>
-            | React.MouseEvent<HTMLDivElement>,
+        event: React.MouseEvent<HTMLSpanElement | HTMLDivElement>,
     ) => void;
-    onMouseLeave?: () => void;
+    onMouseLeave?: (
+        event: React.MouseEvent<HTMLSpanElement | HTMLDivElement>,
+    ) => void;
 }
 
 const StoryCircle = ({

--- a/src/components/Direct/Aside/AsideBody.tsx
+++ b/src/components/Direct/Aside/AsideBody.tsx
@@ -1,6 +1,5 @@
 import ChatList from "./ChatList";
 // 이런 식으로 type을 가져와서 제가 필요한 모듈을 가져와요
-import { Direct } from "@type";
 
 // 그 다음 그 모듈 안에서 제가 export 한 타입을 가져와서 사용하는 방식입니다.
 

--- a/src/components/Direct/Aside/ChatList/ChatList.type.ts
+++ b/src/components/Direct/Aside/ChatList/ChatList.type.ts
@@ -1,5 +1,3 @@
-import { Direct } from "@type";
-
 export default interface ChatListProps {
     chatList: Array<Direct.ChatItem>;
 }

--- a/src/components/Direct/Aside/ChatList/ChatListItem/ChatListItem.tsx
+++ b/src/components/Direct/Aside/ChatList/ChatListItem/ChatListItem.tsx
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { Direct } from "@type";
 import moment from "moment";
 import "moment/locale/ko";
 

--- a/src/components/Home/Article/Article.tsx
+++ b/src/components/Home/Article/Article.tsx
@@ -10,11 +10,6 @@ import useGapText from "hooks/useGapText";
 import useOnView from "hooks/useOnView";
 import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import { getExtraArticle } from "app/store/ducks/home/homThunk";
-import FollowingModal from "components/Home/Modals/FollowingModal";
-import ArticleMenuModal from "components/Home/Modals/ArticleMenuModal";
-import ReportModal from "components/Home/Modals/ReportModal";
-import ShareWithModal from "components/Home/Modals/SharerWithModal";
-import { homeActions } from "app/store/ducks/home/homeSlice";
 
 const ArticleCard = styled(Card)`
     margin-bottom: 24px;
@@ -58,10 +53,7 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
     const gapText = useGapText(article.postUploadDate);
     const articleRef = useRef<HTMLDivElement>(null);
     const isVisible = useOnView(articleRef);
-    const {
-        home: { extraArticlesCount },
-        modal: { activatedModal, postId, memberNickname },
-    } = useAppSelector((state) => state);
+    const { extraArticlesCount } = useAppSelector(({ home }) => home);
     const dispatch = useAppDispatch();
 
     useEffect(() => {

--- a/src/components/Home/Article/Article.tsx
+++ b/src/components/Home/Article/Article.tsx
@@ -10,6 +10,7 @@ import useGapText from "hooks/useGapText";
 import useOnView from "hooks/useOnView";
 import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import { getExtraArticle } from "app/store/ducks/home/homThunk";
+import { token } from "Routes";
 
 const ArticleCard = styled(Card)`
     margin-bottom: 24px;
@@ -29,14 +30,6 @@ const ArticleCard = styled(Card)`
         }
     }
 `;
-
-const token = {
-    accessToken:
-        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTY0MzA0OTI2MH0.fEZRuRii2e4FkUNH4ko99MXrpD2ONClZJ0jKJxvCI-KDYxE7HnV61Kx3_Awk0jyv0VWEB6F-dMyS7K2GSCD56Q",
-    refreshToken:
-        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiZXhwIjoxNjQyNzQxNDY4fQ.8mHe22G6uu6F_HB-5G8A7voUNLb5oRAuX84xlKWFUZeccsi_Y3DHMh1fC7w3uEG3UATvNc5U9PBPvF6hW1vpZw",
-};
-
 interface ArticleComponentPros {
     article: HomeType.ArticleProps;
     isObserving: boolean;
@@ -62,7 +55,7 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
             try {
                 await dispatch(
                     getExtraArticle({
-                        token: token.accessToken,
+                        token,
                         page: extraArticlesCount + 1,
                     }),
                 );

--- a/src/components/Home/Article/Article.tsx
+++ b/src/components/Home/Article/Article.tsx
@@ -7,8 +7,8 @@ import ArticleMainIcons from "components/Home/Article/ArticleMainIcons";
 import ArticleMain from "components/Home/Article/ArticleMain";
 import CommentForm from "components/Home/Article/CommentForm";
 import { HomeType } from "@type";
-import useGapText from "Hooks/useGapText";
-import useOnView from "Hooks/useOnView";
+import useGapText from "hooks/useGapText";
+import useOnView from "hooks/useOnView";
 import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import { getExtraArticle } from "app/store/ducks/home/homThunk";
 

--- a/src/components/Home/Article/Article.tsx
+++ b/src/components/Home/Article/Article.tsx
@@ -32,7 +32,7 @@ const ArticleCard = styled(Card)`
 
 const token = {
     accessToken:
-        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTY0Mjc3OTY0NH0.Aim3h6qIvauthIAyQrmAFU0w8NAf4ZGNOIbqIKZpE0o88HCMkxJ3RlPbck7BqcO4e41g1Cpdr0HtFT1jAP2EKg",
+        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTY0MzA0OTI2MH0.fEZRuRii2e4FkUNH4ko99MXrpD2ONClZJ0jKJxvCI-KDYxE7HnV61Kx3_Awk0jyv0VWEB6F-dMyS7K2GSCD56Q",
     refreshToken:
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiZXhwIjoxNjQyNzQxNDY4fQ.8mHe22G6uu6F_HB-5G8A7voUNLb5oRAuX84xlKWFUZeccsi_Y3DHMh1fC7w3uEG3UATvNc5U9PBPvF6hW1vpZw",
 };
@@ -88,6 +88,7 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
         <ArticleCard as="article" ref={articleRef}>
             <ArticleHeader
                 memberImageUrl={article.memberImageUrl}
+                memberUsername={article.memberUsername}
                 memberNickname={article.memberNickname}
                 postId={article.postId}
             />
@@ -102,6 +103,7 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
             <ArticleMain
                 followingUserWhoLikesArticle={followingUserWhoLikesArticle}
                 likesCount={article.postLikesCount}
+                memberUsername={article.memberUsername}
                 memberImageUrl={article.memberImageUrl}
                 memberNickname={article.memberNickname}
                 content={article.postContent}

--- a/src/components/Home/Article/Article.tsx
+++ b/src/components/Home/Article/Article.tsx
@@ -6,7 +6,6 @@ import ArticleImgSlider from "components/Home/Article/ArticleImgSlider";
 import ArticleMainIcons from "components/Home/Article/ArticleMainIcons";
 import ArticleMain from "components/Home/Article/ArticleMain";
 import CommentForm from "components/Home/Article/CommentForm";
-import { HomeType } from "@type";
 import useGapText from "hooks/useGapText";
 import useOnView from "hooks/useOnView";
 import { useAppDispatch, useAppSelector } from "app/store/hooks";

--- a/src/components/Home/Article/Article.tsx
+++ b/src/components/Home/Article/Article.tsx
@@ -51,7 +51,6 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
 
     useEffect(() => {
         const dispatchExtraArticle = async () => {
-            console.log("start");
             try {
                 await dispatch(
                     getExtraArticle({

--- a/src/components/Home/Article/Article.tsx
+++ b/src/components/Home/Article/Article.tsx
@@ -11,6 +11,11 @@ import useGapText from "hooks/useGapText";
 import useOnView from "hooks/useOnView";
 import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import { getExtraArticle } from "app/store/ducks/home/homThunk";
+import FollowingModal from "components/Home/Modals/FollowingModal";
+import ArticleMenuModal from "components/Home/Modals/ArticleMenuModal";
+import ReportModal from "components/Home/Modals/ReportModal";
+import ShareWithModal from "components/Home/Modals/SharerWithModal";
+import { homeActions } from "app/store/ducks/home/homeSlice";
 
 const ArticleCard = styled(Card)`
     margin-bottom: 24px;
@@ -33,7 +38,7 @@ const ArticleCard = styled(Card)`
 
 const token = {
     accessToken:
-        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTY0MjQxODcxMH0.a54MJzWdP3Mjs1yXG33v7ti0SpHcN7IzqfwQ9nFdVSjmhriTcFA_tc5yHFWyLA_PRCH3A_TUk0WPRQ_0dEacjw",
+        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTY0Mjc3OTY0NH0.Aim3h6qIvauthIAyQrmAFU0w8NAf4ZGNOIbqIKZpE0o88HCMkxJ3RlPbck7BqcO4e41g1Cpdr0HtFT1jAP2EKg",
     refreshToken:
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiZXhwIjoxNjQyNzQxNDY4fQ.8mHe22G6uu6F_HB-5G8A7voUNLb5oRAuX84xlKWFUZeccsi_Y3DHMh1fC7w3uEG3UATvNc5U9PBPvF6hW1vpZw",
 };
@@ -54,9 +59,10 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
     const gapText = useGapText(article.postUploadDate);
     const articleRef = useRef<HTMLDivElement>(null);
     const isVisible = useOnView(articleRef);
-    const extraArticlesCount = useAppSelector(
-        ({ home }) => home.extraArticlesCount,
-    );
+    const {
+        extraArticlesCount,
+        modalDTOs: { activatedModal, postId, memberNickname },
+    } = useAppSelector(({ home }) => home);
     const dispatch = useAppDispatch();
 
     useEffect(() => {
@@ -92,6 +98,7 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
             <ArticleHeader
                 memberImageUrl={article.memberImageUrl}
                 memberNickname={article.memberNickname}
+                postId={article.postId}
             />
             <ArticleImgSlider
                 imageDTOs={article.postImageDTOs}

--- a/src/components/Home/Article/Article.tsx
+++ b/src/components/Home/Article/Article.tsx
@@ -31,7 +31,7 @@ const ArticleCard = styled(Card)`
     }
 `;
 interface ArticleComponentPros {
-    article: HomeType.ArticleProps;
+    article: HomeType.ArticleStateProps;
     isObserving: boolean;
     isLast: boolean;
 }
@@ -83,6 +83,8 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
                 memberUsername={article.memberUsername}
                 memberNickname={article.memberNickname}
                 postId={article.postId}
+                isFollowing={article.isFollowing}
+                followLoading={article.followLoading}
             />
             <ArticleImgSlider
                 imageDTOs={article.postImageDTOs}

--- a/src/components/Home/Article/Article.tsx
+++ b/src/components/Home/Article/Article.tsx
@@ -59,9 +59,9 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
     const articleRef = useRef<HTMLDivElement>(null);
     const isVisible = useOnView(articleRef);
     const {
-        extraArticlesCount,
-        modalDTOs: { activatedModal, postId, memberNickname },
-    } = useAppSelector(({ home }) => home);
+        home: { extraArticlesCount },
+        modal: { activatedModal, postId, memberNickname },
+    } = useAppSelector((state) => state);
     const dispatch = useAppDispatch();
 
     useEffect(() => {

--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -11,6 +11,7 @@ import ShareWithModal from "../Modals/SharerWithModal";
 import { ReactComponent as ThreeDots } from "../../../assets/Svgs/threeDots.svg";
 import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import { homeActions } from "app/store/ducks/home/homeSlice";
+import { modalActions } from "app/store/ducks/modal/modalSlice";
 
 const StyledArticleHeader = styled.header`
     height: 60px;
@@ -81,7 +82,7 @@ const ArticleHeader = ({
     // const [isShareWithModalActivated, setIsShareWithModalActivated] =
     //     useState(false);
 
-    const { activatedModal } = useAppSelector(({ home }) => home.modalDTOs);
+    const activatedModal = useAppSelector(({ modal }) => modal.activatedModal);
     const dispatch = useAppDispatch();
 
     // const [modalPositionObj, setModalPositionObj] = useState<DOMRect>();
@@ -98,7 +99,7 @@ const ArticleHeader = ({
         const { top, bottom, left } =
             event.currentTarget.getBoundingClientRect();
         dispatch(
-            homeActions.startModal({
+            modalActions.startModal({
                 activatedModal: "hover",
                 modalPosition: {
                     top,
@@ -114,7 +115,7 @@ const ArticleHeader = ({
         // setTimeout(() => {
         //     activatedModal || dispatch(homeActions.resetModal());
         // }, 500);
-        dispatch(homeActions.resetModal());
+        dispatch(modalActions.resetModal());
         // setIsHoverModalActivated(false);
     };
 
@@ -206,7 +207,7 @@ const ArticleHeader = ({
                 className="header-dots"
                 onClick={() =>
                     dispatch(
-                        homeActions.startModal({
+                        modalActions.startModal({
                             activatedModal: "articleMenu",
                             postId: postId,
                             memberNickname,

--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -3,14 +3,8 @@ import Username from "components/Common/Username";
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-import ArticleMenuModal from "../Modals/ArticleMenuModal";
-import FollowingModal from "../Modals/FollowingModal";
-import HoverModal from "../Modals/HoverModal";
-import ReportModal from "../Modals/ReportModal";
-import ShareWithModal from "../Modals/SharerWithModal";
 import { ReactComponent as ThreeDots } from "../../../assets/Svgs/threeDots.svg";
-import { useAppDispatch, useAppSelector } from "app/store/hooks";
-import { homeActions } from "app/store/ducks/home/homeSlice";
+import { useAppDispatch } from "app/store/hooks";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
 
 const StyledArticleHeader = styled.header`
@@ -74,18 +68,8 @@ const ArticleHeader = ({
     postId,
     location,
 }: ArticleHeaderProps) => {
-    // const [isHoverModalActivated, setIsHoverModalActivated] = useState(false);
-    // const [isDotModalActivated, setIsDotModalActivated] = useState(false);
-    // const [isReportModalActivated, setIsReportModalActivated] = useState(false);
-    // const [isFollowingModalActivated, setIsFollowingModalActivated] =
-    //     useState(false);
-    // const [isShareWithModalActivated, setIsShareWithModalActivated] =
-    //     useState(false);
-
-    const activatedModal = useAppSelector(({ modal }) => modal.activatedModal);
     const dispatch = useAppDispatch();
 
-    // const [modalPositionObj, setModalPositionObj] = useState<DOMRect>();
     const [isFollowing, setIsFollowing] = useState(false); // followingModal의 isFollowing과 연결할 것
 
     const mouseEnterHandler = (
@@ -93,8 +77,6 @@ const ArticleHeader = ({
             | React.MouseEvent<HTMLSpanElement>
             | React.MouseEvent<HTMLDivElement>,
     ) => {
-        // se  tModalPositionObj(event?.currentTarget.getBoundingClientRect());
-        // setIsHoverModalActivated(true);
         if (!event) return;
         const { top, bottom, left } =
             event.currentTarget.getBoundingClientRect();
@@ -112,11 +94,7 @@ const ArticleHeader = ({
     };
 
     const mouseLeaveHandler = () => {
-        // setTimeout(() => {
-        //     activatedModal || dispatch(homeActions.resetModal());
-        // }, 500);
         dispatch(modalActions.resetModal());
-        // setIsHoverModalActivated(false);
     };
 
     const followHandler = () => {
@@ -124,57 +102,8 @@ const ArticleHeader = ({
         setIsFollowing(true);
     };
 
-    // const unfollowHandler = () => {
-    //     // unfollow하기 전에 modal에서 재차 확인
-    //     setIsFollowingModalActivated(true);
-    // };
-
-    // const cloaseArticleMenuModalAndOpenReportModal = () => {
-    //     setIsDotModalActivated(false);
-    //     setIsReportModalActivated(true);
-    // };
-
-    // const cloaseArticleMenuModalAndOpenShareWithModal = () => {
-    //     setIsDotModalActivated(false);
-    //     setIsShareWithModalActivated(true);
-    // };
-
     return (
         <StyledArticleHeader>
-            {/* {isFollowing && activatedModal === "unfollowing" && (
-                <FollowingModal
-                    onUnfollow={() => setIsFollowing(false)}
-                    onModalOn={() => setIsFollowingModalActivated(true)}
-                    onModalOff={() => setIsFollowingModalActivated(false)}
-                    username={memberNickname}
-                    avatarUrl={memberImageUrl}
-                />
-            )}
-            {activatedModal === "articleMenu" && (
-                <ArticleMenuModal
-                    isFollowing={isFollowing}
-                    onUnfollow={unfollowHandler}
-                    onModalOn={() => setIsDotModalActivated(true)}
-                    onModalOff={() => setIsDotModalActivated(false)}
-                    onReportModalOn={cloaseArticleMenuModalAndOpenReportModal}
-                    onShareWithModalOn={
-                        cloaseArticleMenuModalAndOpenShareWithModal
-                    }
-                />
-            )}
-            {activatedModal === "report" && (
-                <ReportModal
-                    onModalOn={() => setIsReportModalActivated(true)}
-                    onModalOff={() => setIsReportModalActivated(false)}
-                />
-            )}
-            {activatedModal === "shareWith" && (
-                <ShareWithModal
-                    onModalOn={() => setIsShareWithModalActivated(true)}
-                    onModalOff={() => setIsShareWithModalActivated(false)}
-                    username={memberNickname}
-                />
-            )} */}
             <StoryCircle
                 type="unread" // 백엔드 소통하여 읽었는지 여부 확인
                 avatarUrl={memberImageUrl}

--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -57,6 +57,7 @@ const HEADER_STORY_CIRCLE = 42 / 64;
 
 interface ArticleHeaderProps {
     memberImageUrl: string;
+    memberUsername: string;
     memberNickname: string;
     postId: number;
     location?: string;
@@ -64,6 +65,7 @@ interface ArticleHeaderProps {
 
 const ArticleHeader = ({
     memberImageUrl,
+    memberUsername,
     memberNickname,
     postId,
     location,
@@ -88,6 +90,7 @@ const ArticleHeader = ({
                     bottom,
                     left,
                 },
+                memberUsername,
                 memberNickname,
             }),
         );
@@ -139,6 +142,7 @@ const ArticleHeader = ({
                         modalActions.startModal({
                             activatedModal: "articleMenu",
                             postId: postId,
+                            memberUsername,
                             memberNickname,
                             memberImageUrl,
                         }),

--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -8,6 +8,8 @@ import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
 import { getMiniProfile } from "app/store/ducks/modal/modalThunk";
 import { token } from "Routes";
+import { postFollow } from "app/store/ducks/home/homThunk";
+import Loading from "components/Common/Loading";
 
 const StyledArticleHeader = styled.header`
     height: 60px;
@@ -32,10 +34,16 @@ const StyledArticleHeader = styled.header`
             display: flex;
         }
         .header-followBox {
+            display: flex;
+            align-items: center;
             & > span {
                 margin: 0 4px;
             }
             & > button {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                width: 36.34px;
                 margin-left: 2px;
                 color: ${(props) => props.theme.color.blue};
             }
@@ -63,6 +71,8 @@ interface ArticleHeaderProps {
     memberNickname: string;
     postId: number;
     location?: string;
+    isFollowing: boolean;
+    followLoading: boolean;
 }
 
 const ArticleHeader = ({
@@ -71,11 +81,13 @@ const ArticleHeader = ({
     memberNickname,
     postId,
     location,
+    isFollowing,
+    followLoading,
 }: ArticleHeaderProps) => {
     const { miniProfile } = useAppSelector(({ modal }) => modal);
     const dispatch = useAppDispatch();
 
-    const [isFollowing, setIsFollowing] = useState(false); // followingModal의 isFollowing과 연결할 것
+    // const [isFollowing, setIsFollowing] = useState(false); // followingModal의 isFollowing과 연결할 것
     const [prevEventText, setPrevEventText] = useState("");
 
     const fetchMiniProfile = async () => {
@@ -121,22 +133,16 @@ const ArticleHeader = ({
         const {
             currentTarget: { innerText },
         } = event;
-        // console.log("떨어진 텍스트는", innerText);
-        // console.log("현재 텍스트는", prevEventText);
         setPrevEventText(innerText);
-        // if (innerText !== prevEventText) {
-        //     console.log("다릅니다");
-        //     setPrevEventText(innerText);
-        //     dispatch(modalActions.resetModal());
-        // } else {
         dispatch(modalActions.mouseNotOnHoverModal());
-        setTimeout(() => dispatch(modalActions.checkMouseOnHoverModal()), 100);
-        // }
+        setTimeout(() => dispatch(modalActions.checkMouseOnHoverModal()), 500);
     };
 
     const followHandler = () => {
-        // follow
-        setIsFollowing(true);
+        const followUser = async () => {
+            await dispatch(postFollow({ token, username: memberUsername }));
+        };
+        followUser();
     };
 
     return (
@@ -160,8 +166,14 @@ const ArticleHeader = ({
                     {!isFollowing && (
                         <div className="header-followBox">
                             <span>•</span>
-                            <button onClick={followHandler}>팔로우</button>
-                        </div>
+                            <button onClick={followHandler}>
+                                {followLoading ? (
+                                    <Loading size={18} />
+                                ) : (
+                                    "팔로우"
+                                )}
+                            </button>
+                        </div> // 로딩 처리 필요
                     )}
                 </div>
                 <Link to={`/explore/locations/:id/${location}`}>

--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -4,8 +4,10 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { ReactComponent as ThreeDots } from "../../../assets/Svgs/threeDots.svg";
-import { useAppDispatch } from "app/store/hooks";
+import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
+import { getMiniProfile } from "app/store/ducks/modal/modalThunk";
+import { token } from "Routes";
 
 const StyledArticleHeader = styled.header`
     height: 60px;
@@ -70,21 +72,35 @@ const ArticleHeader = ({
     postId,
     location,
 }: ArticleHeaderProps) => {
+    const { miniProfile } = useAppSelector(({ modal }) => modal);
     const dispatch = useAppDispatch();
 
     const [isFollowing, setIsFollowing] = useState(false); // followingModal의 isFollowing과 연결할 것
+    const [prevEventText, setPrevEventText] = useState("");
+
+    const fetchMiniProfile = async () => {
+        await dispatch(getMiniProfile({ token, memberUsername }));
+    };
 
     const mouseEnterHandler = (
-        event:
-            | React.MouseEvent<HTMLSpanElement>
-            | React.MouseEvent<HTMLDivElement>,
+        event: React.MouseEvent<HTMLSpanElement | HTMLDivElement>,
     ) => {
         if (!event) return;
+        const {
+            currentTarget: { innerText },
+        } = event;
         const { top, bottom, left } =
             event.currentTarget.getBoundingClientRect();
+        if (innerText !== prevEventText) {
+            dispatch(
+                modalActions.changeHoverModalPosition({ top, bottom, left }),
+            );
+        }
+        if (miniProfile) return dispatch(modalActions.mouseOnHoverModal());
         dispatch(
             modalActions.startModal({
-                activatedModal: "hover",
+                activatedModal: null,
+                isOnMiniProfile: false,
                 modalPosition: {
                     top,
                     bottom,
@@ -92,12 +108,30 @@ const ArticleHeader = ({
                 },
                 memberUsername,
                 memberNickname,
+                memberImageUrl,
             }),
         );
+        fetchMiniProfile();
     };
 
-    const mouseLeaveHandler = () => {
-        dispatch(modalActions.resetModal());
+    const mouseLeaveHandler = (
+        event: React.MouseEvent<HTMLSpanElement | HTMLDivElement>,
+    ) => {
+        if (!event) return;
+        const {
+            currentTarget: { innerText },
+        } = event;
+        // console.log("떨어진 텍스트는", innerText);
+        // console.log("현재 텍스트는", prevEventText);
+        setPrevEventText(innerText);
+        // if (innerText !== prevEventText) {
+        //     console.log("다릅니다");
+        //     setPrevEventText(innerText);
+        //     dispatch(modalActions.resetModal());
+        // } else {
+        dispatch(modalActions.mouseNotOnHoverModal());
+        setTimeout(() => dispatch(modalActions.checkMouseOnHoverModal()), 100);
+        // }
     };
 
     const followHandler = () => {
@@ -140,6 +174,7 @@ const ArticleHeader = ({
                 onClick={() =>
                     dispatch(
                         modalActions.startModal({
+                            isOnMiniProfile: false,
                             activatedModal: "articleMenu",
                             postId: postId,
                             memberUsername,

--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -90,8 +90,18 @@ const ArticleHeader = ({
     // const [isFollowing, setIsFollowing] = useState(false); // followingModal의 isFollowing과 연결할 것
     const [prevEventText, setPrevEventText] = useState("");
 
-    const fetchMiniProfile = async () => {
-        await dispatch(getMiniProfile({ token, memberUsername }));
+    const fetchMiniProfile = async ({
+        top,
+        bottom,
+        left,
+    }: ModalType.ModalPositionProps) => {
+        await dispatch(
+            getMiniProfile({
+                token,
+                memberUsername,
+                modalPosition: { top, bottom, left },
+            }),
+        );
     };
 
     const mouseEnterHandler = (
@@ -113,17 +123,16 @@ const ArticleHeader = ({
             modalActions.startModal({
                 activatedModal: null,
                 isOnMiniProfile: false,
-                modalPosition: {
-                    top,
-                    bottom,
-                    left,
-                },
                 memberUsername,
                 memberNickname,
                 memberImageUrl,
             }),
         );
-        fetchMiniProfile();
+        fetchMiniProfile({
+            top,
+            bottom,
+            left,
+        });
     };
 
     const mouseLeaveHandler = (

--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -126,6 +126,7 @@ const ArticleHeader = ({
                 memberUsername,
                 memberNickname,
                 memberImageUrl,
+                isFollowing,
             }),
         );
         fetchMiniProfile({
@@ -201,6 +202,7 @@ const ArticleHeader = ({
                             memberUsername,
                             memberNickname,
                             memberImageUrl,
+                            isFollowing,
                         }),
                     )
                 }

--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -9,6 +9,8 @@ import HoverModal from "../Modals/HoverModal";
 import ReportModal from "../Modals/ReportModal";
 import ShareWithModal from "../Modals/SharerWithModal";
 import { ReactComponent as ThreeDots } from "../../../assets/Svgs/threeDots.svg";
+import { useAppDispatch, useAppSelector } from "app/store/hooks";
+import { homeActions } from "app/store/ducks/home/homeSlice";
 
 const StyledArticleHeader = styled.header`
     height: 60px;
@@ -61,23 +63,28 @@ const HEADER_STORY_CIRCLE = 42 / 64;
 interface ArticleHeaderProps {
     memberImageUrl: string;
     memberNickname: string;
+    postId: number;
     location?: string;
 }
 
 const ArticleHeader = ({
     memberImageUrl,
     memberNickname,
+    postId,
     location,
 }: ArticleHeaderProps) => {
-    const [isHoverModalActivated, setIsHoverModalActivated] = useState(false);
-    const [isDotModalActivated, setIsDotModalActivated] = useState(false);
-    const [isReportModalActivated, setIsReportModalActivated] = useState(false);
-    const [isFollowingModalActivated, setIsFollowingModalActivated] =
-        useState(false);
-    const [isShareWithModalActivated, setIsShareWithModalActivated] =
-        useState(false);
+    // const [isHoverModalActivated, setIsHoverModalActivated] = useState(false);
+    // const [isDotModalActivated, setIsDotModalActivated] = useState(false);
+    // const [isReportModalActivated, setIsReportModalActivated] = useState(false);
+    // const [isFollowingModalActivated, setIsFollowingModalActivated] =
+    //     useState(false);
+    // const [isShareWithModalActivated, setIsShareWithModalActivated] =
+    //     useState(false);
 
-    const [modalPositionObj, setModalPositionObj] = useState<DOMRect>();
+    const { activatedModal } = useAppSelector(({ home }) => home.modalDTOs);
+    const dispatch = useAppDispatch();
+
+    // const [modalPositionObj, setModalPositionObj] = useState<DOMRect>();
     const [isFollowing, setIsFollowing] = useState(false); // followingModal의 isFollowing과 연결할 것
 
     const mouseEnterHandler = (
@@ -85,12 +92,30 @@ const ArticleHeader = ({
             | React.MouseEvent<HTMLSpanElement>
             | React.MouseEvent<HTMLDivElement>,
     ) => {
-        setModalPositionObj(event?.currentTarget.getBoundingClientRect());
-        setIsHoverModalActivated(true);
+        // se  tModalPositionObj(event?.currentTarget.getBoundingClientRect());
+        // setIsHoverModalActivated(true);
+        if (!event) return;
+        const { top, bottom, left } =
+            event.currentTarget.getBoundingClientRect();
+        dispatch(
+            homeActions.startModal({
+                activatedModal: "hover",
+                modalPosition: {
+                    top,
+                    bottom,
+                    left,
+                },
+                memberNickname,
+            }),
+        );
     };
 
     const mouseLeaveHandler = () => {
-        setIsHoverModalActivated(false);
+        // setTimeout(() => {
+        //     activatedModal || dispatch(homeActions.resetModal());
+        // }, 500);
+        dispatch(homeActions.resetModal());
+        // setIsHoverModalActivated(false);
     };
 
     const followHandler = () => {
@@ -98,37 +123,24 @@ const ArticleHeader = ({
         setIsFollowing(true);
     };
 
-    const unfollowHandler = () => {
-        // unfollow하기 전에 modal에서 재차 확인
-        setIsFollowingModalActivated(true);
-    };
+    // const unfollowHandler = () => {
+    //     // unfollow하기 전에 modal에서 재차 확인
+    //     setIsFollowingModalActivated(true);
+    // };
 
-    const cloaseArticleMenuModalAndOpenReportModal = () => {
-        setIsDotModalActivated(false);
-        setIsReportModalActivated(true);
-    };
+    // const cloaseArticleMenuModalAndOpenReportModal = () => {
+    //     setIsDotModalActivated(false);
+    //     setIsReportModalActivated(true);
+    // };
 
-    const cloaseArticleMenuModalAndOpenShareWithModal = () => {
-        setIsDotModalActivated(false);
-        setIsShareWithModalActivated(true);
-    };
+    // const cloaseArticleMenuModalAndOpenShareWithModal = () => {
+    //     setIsDotModalActivated(false);
+    //     setIsShareWithModalActivated(true);
+    // };
 
     return (
         <StyledArticleHeader>
-            {isHoverModalActivated && (
-                <HoverModal
-                    isFollowing={isFollowing}
-                    onFollowChange={(a: boolean) => setIsFollowing(a)}
-                    username={memberNickname}
-                    modalPosition={modalPositionObj}
-                    onMouseEnter={() => setIsHoverModalActivated(true)}
-                    onMouseLeave={() => setIsHoverModalActivated(false)}
-                    onFollowingModalOn={() =>
-                        setIsFollowingModalActivated(true)
-                    }
-                />
-            )}
-            {isFollowing && isFollowingModalActivated && (
+            {/* {isFollowing && activatedModal === "unfollowing" && (
                 <FollowingModal
                     onUnfollow={() => setIsFollowing(false)}
                     onModalOn={() => setIsFollowingModalActivated(true)}
@@ -137,7 +149,7 @@ const ArticleHeader = ({
                     avatarUrl={memberImageUrl}
                 />
             )}
-            {isDotModalActivated && (
+            {activatedModal === "articleMenu" && (
                 <ArticleMenuModal
                     isFollowing={isFollowing}
                     onUnfollow={unfollowHandler}
@@ -149,19 +161,19 @@ const ArticleHeader = ({
                     }
                 />
             )}
-            {isReportModalActivated && (
+            {activatedModal === "report" && (
                 <ReportModal
                     onModalOn={() => setIsReportModalActivated(true)}
                     onModalOff={() => setIsReportModalActivated(false)}
                 />
             )}
-            {isShareWithModalActivated && (
+            {activatedModal === "shareWith" && (
                 <ShareWithModal
                     onModalOn={() => setIsShareWithModalActivated(true)}
                     onModalOff={() => setIsShareWithModalActivated(false)}
                     username={memberNickname}
                 />
-            )}
+            )} */}
             <StoryCircle
                 type="unread" // 백엔드 소통하여 읽었는지 여부 확인
                 avatarUrl={memberImageUrl}
@@ -192,7 +204,16 @@ const ArticleHeader = ({
             </div>
             <div
                 className="header-dots"
-                onClick={() => setIsDotModalActivated(true)}
+                onClick={() =>
+                    dispatch(
+                        homeActions.startModal({
+                            activatedModal: "articleMenu",
+                            postId: postId,
+                            memberNickname,
+                            memberImageUrl,
+                        }),
+                    )
+                }
             >
                 <ThreeDots />
             </div>

--- a/src/components/Home/Article/ArticleImgSlider/ArticleImgSlider.tsx
+++ b/src/components/Home/Article/ArticleImgSlider/ArticleImgSlider.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useState } from "react";
 import sprite2 from "assets/Images/sprite2.png";
 import styled from "styled-components";
-import { HomeType } from "@type";
 import ArticleImgSliderUnit from "components/Home/Article/ArticleImgSlider/ArticleImgSliderUnit";
 
 interface SliderProps {

--- a/src/components/Home/Article/ArticleImgSlider/ArticleImgSliderUnit.tsx
+++ b/src/components/Home/Article/ArticleImgSlider/ArticleImgSliderUnit.tsx
@@ -1,4 +1,3 @@
-import { HomeType } from "@type";
 import ImgHashTagAvatar from "components/Home/Article/ArticleImgSlider/ImgHashTagAvatar";
 import ImgHashTagUsername from "components/Home/Article/ArticleImgSlider/ImgHashTagUsername";
 import React, { useState } from "react";

--- a/src/components/Home/Article/ArticleImgSlider/ImgHashTagUsername.tsx
+++ b/src/components/Home/Article/ArticleImgSlider/ImgHashTagUsername.tsx
@@ -1,4 +1,3 @@
-import { HomeType } from "@type";
 import React from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";

--- a/src/components/Home/Article/ArticleMain.tsx
+++ b/src/components/Home/Article/ArticleMain.tsx
@@ -93,33 +93,18 @@ const ArticleMain = ({
         // 백엔드 수행
     };
 
-    // const mouseEnterHandler = (
-    //     event:
-    //         | React.MouseEvent<HTMLSpanElement>
-    //         | React.MouseEvent<HTMLDivElement>,
-    // ) => {
-    //     if (!event) return;
-    //     const { top, bottom, left } =
-    //         event.currentTarget.getBoundingClientRect();
-    //     dispatch(
-    //         modalActions.startModal({
-    //             activatedModal: null,
-    //             isOnMiniProfile: true,
-    //             modalPosition: {
-    //                 top,
-    //                 bottom,
-    //                 left,
-    //             },
-    //             // 댓글 nickname에 hover 했을 때는 다르게 해야
-    //             memberNickname: event.currentTarget.innerText, // 이후 체크
-    //             memberUsername, // 댓글 username이 제공될 때
-    //             memberImageUrl,
-    //         }),
-    //     );
-    // };
-
-    const fetchMiniProfile = async () => {
-        await dispatch(getMiniProfile({ token, memberUsername }));
+    const fetchMiniProfile = async ({
+        top,
+        bottom,
+        left,
+    }: ModalType.ModalPositionProps) => {
+        await dispatch(
+            getMiniProfile({
+                token,
+                memberUsername,
+                modalPosition: { top, bottom, left },
+            }),
+        );
     };
 
     const mouseEnterHandler = (
@@ -135,18 +120,17 @@ const ArticleMain = ({
             modalActions.startModal({
                 activatedModal: null,
                 isOnMiniProfile: true,
-                modalPosition: {
-                    top,
-                    bottom,
-                    left,
-                },
                 // 댓글 nickname에 hover 했을 때는 다르게 해야
                 memberNickname: event.currentTarget.innerText, // 이후 체크
                 memberUsername, // 댓글 username이 제공될 때
                 memberImageUrl,
             }),
         );
-        fetchMiniProfile();
+        fetchMiniProfile({
+            top,
+            bottom,
+            left,
+        });
     };
 
     const mouseLeaveHandler = () => {

--- a/src/components/Home/Article/ArticleMain.tsx
+++ b/src/components/Home/Article/ArticleMain.tsx
@@ -4,6 +4,8 @@ import styled from "styled-components";
 import FollowingModal from "../Modals/FollowingModal";
 import HoverModal from "../Modals/HoverModal";
 import Username from "../../Common/Username";
+import { homeActions } from "app/store/ducks/home/homeSlice";
+import { useAppDispatch } from "app/store/hooks";
 
 const StyledMain = styled.div`
     padding: 0 16px;
@@ -63,12 +65,13 @@ const ArticleMain = ({
     const [isComment1Liked, setIsComment1Liked] = useState(false); // 백엔드에서 이 코멘트 좋아요 한 사람 중 내가 있는지 확인
     const [isComment2Liked, setIsComment2Liked] = useState(false); // 백엔드에서 이 코멘트 좋아요 한 사람 중 내가 있는지 확인
     const [isFullText, setIsFullText] = useState(false);
-    const [isHoverModalActivated, setIsHoverModalActivated] = useState(false);
-    const [isFollowingModalActivated, setIsFollowingModalActivated] =
-        useState(false);
-    const [modalPositionObj, setModalPositionObj] = useState<DOMRect>();
-    const [hoveredUsername, setHoveredUsername] = useState("");
-    const [ishoveredUserFollowing, setIsHoveredUserFollowing] = useState(false); // hover한 데이터 가져와서 적용
+    const dispatch = useAppDispatch();
+    // const [isHoverModalActivated, setIsHoverModalActivated] = useState(false);
+    // const [isFollowingModalActivated, setIsFollowingModalActivated] =
+    //     useState(false);
+    // const [modalPositionObj, setModalPositionObj] = useState<DOMRect>();
+    // const [hoveredUsername, setHoveredUsername] = useState("");
+    // const [ishoveredUserFollowing, setIsHoveredUserFollowing] = useState(false); // hover한 데이터 가져와서 적용
     const isTextLineBreak = content.includes("\n");
     const textArray = isTextLineBreak ? content.split("\n") : [content];
 
@@ -98,19 +101,35 @@ const ArticleMain = ({
             | React.MouseEvent<HTMLSpanElement>
             | React.MouseEvent<HTMLDivElement>,
     ) => {
-        setHoveredUsername(event.currentTarget.innerText);
-        setModalPositionObj(event?.currentTarget.getBoundingClientRect());
-        setIsHoverModalActivated(true);
+        // setHoveredUsername(event.currentTarget.innerText);
+        // setModalPositionObj(event?.currentTarget.getBoundingClientRect());
+        // setIsHoverModalActivated(true);
+
+        if (!event) return;
+        const { top, bottom, left } =
+            event.currentTarget.getBoundingClientRect();
+        dispatch(
+            homeActions.startModal({
+                activatedModal: "hover",
+                modalPosition: {
+                    top,
+                    bottom,
+                    left,
+                },
+                memberNickname: event.currentTarget.innerText, // 이후 체크
+            }),
+        );
     };
 
     const mouseLeaveHandler = () => {
-        setIsHoverModalActivated(false);
+        // setIsHoverModalActivated(false);
+        dispatch(homeActions.resetModal());
     };
 
     const getFullText = () => setIsFullText(true);
     return (
         <StyledMain>
-            {isHoverModalActivated && (
+            {/* {isHoverModalActivated && (
                 <HoverModal
                     isFollowing={ishoveredUserFollowing} // hover username 데이터 가져오면 필요 없음
                     onFollowChange={(a: boolean) =>
@@ -135,7 +154,7 @@ const ArticleMain = ({
                     username={hoveredUsername}
                     avatarUrl={memberImageUrl} // 원래 FollowingModal 내부에서 username에 따라 받아와야 함.
                 />
-            )}
+            )} */}
             <div className="article-likeInfo">
                 {followingUserWhoLikesArticle ? (
                     <div>

--- a/src/components/Home/Article/ArticleMain.tsx
+++ b/src/components/Home/Article/ArticleMain.tsx
@@ -40,6 +40,7 @@ const StyledMain = styled.div`
 interface MainProps {
     followingUserWhoLikesArticle: null | string;
     likesCount: number;
+    memberUsername: string;
     memberNickname: string;
     memberImageUrl: string;
     content: string;
@@ -54,6 +55,7 @@ interface MainProps {
 const ArticleMain = ({
     followingUserWhoLikesArticle,
     likesCount,
+    memberUsername,
     memberNickname,
     memberImageUrl,
     content,
@@ -114,7 +116,10 @@ const ArticleMain = ({
                     bottom,
                     left,
                 },
+                // 댓글 nickname에 hover 했을 때는 다르게 해야
                 memberNickname: event.currentTarget.innerText, // 이후 체크
+                memberUsername,
+                memberImageUrl,
             }),
         );
     };
@@ -127,32 +132,6 @@ const ArticleMain = ({
     const getFullText = () => setIsFullText(true);
     return (
         <StyledMain>
-            {/* {isHoverModalActivated && (
-                <HoverModal
-                    isFollowing={ishoveredUserFollowing} // hover username 데이터 가져오면 필요 없음
-                    onFollowChange={(a: boolean) =>
-                        setIsHoveredUserFollowing(a)
-                    }
-                    username={hoveredUsername}
-                    modalPosition={modalPositionObj}
-                    onMouseEnter={() => setIsHoverModalActivated(true)}
-                    onMouseLeave={() => setIsHoverModalActivated(false)}
-                    onFollowingModalOn={() =>
-                        setIsFollowingModalActivated(true)
-                    }
-                />
-            )}
-            {ishoveredUserFollowing && isFollowingModalActivated && (
-                <FollowingModal
-                    onUnfollow={() => {
-                        setIsHoveredUserFollowing(false);
-                    }}
-                    onModalOn={() => setIsFollowingModalActivated(true)}
-                    onModalOff={() => setIsFollowingModalActivated(false)}
-                    username={hoveredUsername}
-                    avatarUrl={memberImageUrl} // 원래 FollowingModal 내부에서 username에 따라 받아와야 함.
-                />
-            )} */}
             <div className="article-likeInfo">
                 {followingUserWhoLikesArticle ? (
                     <div>

--- a/src/components/Home/Article/ArticleMain.tsx
+++ b/src/components/Home/Article/ArticleMain.tsx
@@ -122,8 +122,11 @@ const ArticleMain = ({
                 isOnMiniProfile: true,
                 // 댓글 nickname에 hover 했을 때는 다르게 해야
                 memberNickname: event.currentTarget.innerText, // 이후 체크
-                memberUsername, // 댓글 username이 제공될 때
+                memberUsername,
                 memberImageUrl,
+                // 댓글 username이 제공될 때 예시
+                // memberUsername:comments.memberUsername,
+                // memberImageUrl:comments.imageUrl,
             }),
         );
         fetchMiniProfile({

--- a/src/components/Home/Article/ArticleMain.tsx
+++ b/src/components/Home/Article/ArticleMain.tsx
@@ -2,8 +2,10 @@ import PopHeart from "components/Common/PopHeart";
 import React, { useState } from "react";
 import styled from "styled-components";
 import Username from "../../Common/Username";
-import { useAppDispatch } from "app/store/hooks";
+import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
+import { getMiniProfile } from "app/store/ducks/modal/modalThunk";
+import { token } from "Routes";
 
 const StyledMain = styled.div`
     padding: 0 16px;
@@ -65,13 +67,8 @@ const ArticleMain = ({
     const [isComment1Liked, setIsComment1Liked] = useState(false); // 백엔드에서 이 코멘트 좋아요 한 사람 중 내가 있는지 확인
     const [isComment2Liked, setIsComment2Liked] = useState(false); // 백엔드에서 이 코멘트 좋아요 한 사람 중 내가 있는지 확인
     const [isFullText, setIsFullText] = useState(false);
+    const { miniProfile } = useAppSelector(({ modal }) => modal);
     const dispatch = useAppDispatch();
-    // const [isHoverModalActivated, setIsHoverModalActivated] = useState(false);
-    // const [isFollowingModalActivated, setIsFollowingModalActivated] =
-    //     useState(false);
-    // const [modalPositionObj, setModalPositionObj] = useState<DOMRect>();
-    // const [hoveredUsername, setHoveredUsername] = useState("");
-    // const [ishoveredUserFollowing, setIsHoveredUserFollowing] = useState(false); // hover한 데이터 가져와서 적용
     const isTextLineBreak = content.includes("\n");
     const textArray = isTextLineBreak ? content.split("\n") : [content];
 
@@ -96,21 +93,48 @@ const ArticleMain = ({
         // 백엔드 수행
     };
 
+    // const mouseEnterHandler = (
+    //     event:
+    //         | React.MouseEvent<HTMLSpanElement>
+    //         | React.MouseEvent<HTMLDivElement>,
+    // ) => {
+    //     if (!event) return;
+    //     const { top, bottom, left } =
+    //         event.currentTarget.getBoundingClientRect();
+    //     dispatch(
+    //         modalActions.startModal({
+    //             activatedModal: null,
+    //             isOnMiniProfile: true,
+    //             modalPosition: {
+    //                 top,
+    //                 bottom,
+    //                 left,
+    //             },
+    //             // 댓글 nickname에 hover 했을 때는 다르게 해야
+    //             memberNickname: event.currentTarget.innerText, // 이후 체크
+    //             memberUsername, // 댓글 username이 제공될 때
+    //             memberImageUrl,
+    //         }),
+    //     );
+    // };
+
+    const fetchMiniProfile = async () => {
+        await dispatch(getMiniProfile({ token, memberUsername }));
+    };
+
     const mouseEnterHandler = (
         event:
             | React.MouseEvent<HTMLSpanElement>
             | React.MouseEvent<HTMLDivElement>,
     ) => {
-        // setHoveredUsername(event.currentTarget.innerText);
-        // setModalPositionObj(event?.currentTarget.getBoundingClientRect());
-        // setIsHoverModalActivated(true);
-
         if (!event) return;
+        if (miniProfile) return dispatch(modalActions.mouseOnHoverModal());
         const { top, bottom, left } =
             event.currentTarget.getBoundingClientRect();
         dispatch(
             modalActions.startModal({
-                activatedModal: "hover",
+                activatedModal: null,
+                isOnMiniProfile: true,
                 modalPosition: {
                     top,
                     bottom,
@@ -118,15 +142,16 @@ const ArticleMain = ({
                 },
                 // 댓글 nickname에 hover 했을 때는 다르게 해야
                 memberNickname: event.currentTarget.innerText, // 이후 체크
-                memberUsername,
+                memberUsername, // 댓글 username이 제공될 때
                 memberImageUrl,
             }),
         );
+        fetchMiniProfile();
     };
 
     const mouseLeaveHandler = () => {
-        // setIsHoverModalActivated(false);
-        dispatch(modalActions.resetModal());
+        dispatch(modalActions.mouseNotOnHoverModal());
+        setTimeout(() => dispatch(modalActions.checkMouseOnHoverModal()), 100);
     };
 
     const getFullText = () => setIsFullText(true);

--- a/src/components/Home/Article/ArticleMain.tsx
+++ b/src/components/Home/Article/ArticleMain.tsx
@@ -6,6 +6,7 @@ import HoverModal from "../Modals/HoverModal";
 import Username from "../../Common/Username";
 import { homeActions } from "app/store/ducks/home/homeSlice";
 import { useAppDispatch } from "app/store/hooks";
+import { modalActions } from "app/store/ducks/modal/modalSlice";
 
 const StyledMain = styled.div`
     padding: 0 16px;
@@ -109,7 +110,7 @@ const ArticleMain = ({
         const { top, bottom, left } =
             event.currentTarget.getBoundingClientRect();
         dispatch(
-            homeActions.startModal({
+            modalActions.startModal({
                 activatedModal: "hover",
                 modalPosition: {
                     top,
@@ -123,7 +124,7 @@ const ArticleMain = ({
 
     const mouseLeaveHandler = () => {
         // setIsHoverModalActivated(false);
-        dispatch(homeActions.resetModal());
+        dispatch(modalActions.resetModal());
     };
 
     const getFullText = () => setIsFullText(true);

--- a/src/components/Home/Article/ArticleMain.tsx
+++ b/src/components/Home/Article/ArticleMain.tsx
@@ -1,10 +1,7 @@
 import PopHeart from "components/Common/PopHeart";
 import React, { useState } from "react";
 import styled from "styled-components";
-import FollowingModal from "../Modals/FollowingModal";
-import HoverModal from "../Modals/HoverModal";
 import Username from "../../Common/Username";
-import { homeActions } from "app/store/ducks/home/homeSlice";
 import { useAppDispatch } from "app/store/hooks";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
 

--- a/src/components/Home/HomeSection.tsx
+++ b/src/components/Home/HomeSection.tsx
@@ -2,14 +2,8 @@ import { getHomeArticles } from "app/store/ducks/home/homThunk";
 import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import ExtraLoadingCircle from "components/Home/ExtraLoadingCircle";
 import { useEffect } from "react";
+import { token } from "Routes";
 import Article from "./Article";
-
-const token = {
-    accessToken:
-        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTY0MjQxODcxMH0.a54MJzWdP3Mjs1yXG33v7ti0SpHcN7IzqfwQ9nFdVSjmhriTcFA_tc5yHFWyLA_PRCH3A_TUk0WPRQ_0dEacjw",
-    refreshToken:
-        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiZXhwIjoxNjQyNzQxNDY4fQ.8mHe22G6uu6F_HB-5G8A7voUNLb5oRAuX84xlKWFUZeccsi_Y3DHMh1fC7w3uEG3UATvNc5U9PBPvF6hW1vpZw",
-};
 
 const HomeSection = () => {
     const { articles, isLoading, isExtraArticleLoading } = useAppSelector(
@@ -19,7 +13,7 @@ const HomeSection = () => {
 
     useEffect(() => {
         const fetchData = async () => {
-            await dispatch(getHomeArticles({ token: token.accessToken }));
+            await dispatch(getHomeArticles({ token }));
         };
         fetchData();
         console.log("effect is occur");

--- a/src/components/Home/HomeSection.tsx
+++ b/src/components/Home/HomeSection.tsx
@@ -16,7 +16,6 @@ const HomeSection = () => {
             await dispatch(getHomeArticles({ token }));
         };
         fetchData();
-        console.log("effect is occur");
     }, [dispatch]);
 
     return (

--- a/src/components/Home/Modals/ArticleMenuModal.tsx
+++ b/src/components/Home/Modals/ArticleMenuModal.tsx
@@ -1,5 +1,5 @@
 import { modalActions } from "app/store/ducks/modal/modalSlice";
-import { useAppDispatch } from "app/store/hooks";
+import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import useCopy from "hooks/useCopy";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
@@ -31,8 +31,6 @@ const ArticleMenuModalInner = styled.div`
 `;
 
 interface ArticleMenuModalProps {
-    // isFollowing: boolean;
-    // onUnfollow: () => void;
     onModalOn: () => void;
     onModalOff: () => void;
 }
@@ -41,14 +39,14 @@ const DUMMY_P_ID = "CWWCI-eINvr"; // 게시물 id
 
 const DUMMY_BASE_URL = "https://www.instagram.com"; // 원래 root url: window.location.href
 
-const ArticleMenuModal = ({
-    // isFollowing,
-    // onUnfollow,
-    onModalOn,
-    onModalOff,
-}: ArticleMenuModalProps) => {
+const ArticleMenuModal = ({ onModalOn, onModalOff }: ArticleMenuModalProps) => {
+    const { isFollowing } = useAppSelector(({ modal }) => modal);
     const dispatch = useAppDispatch();
     const copyHandler = useCopy(DUMMY_BASE_URL + "/p/" + DUMMY_P_ID);
+
+    const unFollowClickHandler = () => {
+        dispatch(modalActions.changeActivatedModal("unfollowing"));
+    };
 
     return (
         <ModalCard
@@ -65,14 +63,14 @@ const ArticleMenuModal = ({
                 >
                     신고
                 </div>
-                {/* {isFollowing && (
+                {isFollowing && (
                     <div
                         className="articleMenuModal-unfollow"
-                        onClick={onUnfollow}
+                        onClick={unFollowClickHandler}
                     >
                         팔로우 취소
                     </div>
-                )} */}
+                )}
                 <div>
                     <Link to={`/`}>게시물로 이동</Link>
                     {/* p, tv 등 다양해서 일단 url은 보류 */}

--- a/src/components/Home/Modals/ArticleMenuModal.tsx
+++ b/src/components/Home/Modals/ArticleMenuModal.tsx
@@ -60,11 +60,7 @@ const ArticleMenuModal = ({
                 <div
                     className="articleMenuModal-report"
                     onClick={() =>
-                        dispatch(
-                            modalActions.startModal({
-                                activatedModal: "report",
-                            }),
-                        )
+                        dispatch(modalActions.changeActivatedModal("report"))
                     }
                 >
                     신고
@@ -83,11 +79,7 @@ const ArticleMenuModal = ({
                 </div>
                 <div
                     onClick={() =>
-                        dispatch(
-                            modalActions.startModal({
-                                activatedModal: "shareWith",
-                            }),
-                        )
+                        dispatch(modalActions.changeActivatedModal("shareWith"))
                     }
                 >
                     공유 대상...

--- a/src/components/Home/Modals/ArticleMenuModal.tsx
+++ b/src/components/Home/Modals/ArticleMenuModal.tsx
@@ -1,4 +1,5 @@
 import { homeActions } from "app/store/ducks/home/homeSlice";
+import { modalActions } from "app/store/ducks/modal/modalSlice";
 import { useAppDispatch } from "app/store/hooks";
 import useCopy from "hooks/useCopy";
 import { Link } from "react-router-dom";
@@ -61,7 +62,7 @@ const ArticleMenuModal = ({
                     className="articleMenuModal-report"
                     onClick={() =>
                         dispatch(
-                            homeActions.startModal({
+                            modalActions.startModal({
                                 activatedModal: "report",
                             }),
                         )
@@ -84,7 +85,7 @@ const ArticleMenuModal = ({
                 <div
                     onClick={() =>
                         dispatch(
-                            homeActions.startModal({
+                            modalActions.startModal({
                                 activatedModal: "shareWith",
                             }),
                         )

--- a/src/components/Home/Modals/ArticleMenuModal.tsx
+++ b/src/components/Home/Modals/ArticleMenuModal.tsx
@@ -1,4 +1,3 @@
-import { homeActions } from "app/store/ducks/home/homeSlice";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
 import { useAppDispatch } from "app/store/hooks";
 import useCopy from "hooks/useCopy";

--- a/src/components/Home/Modals/ArticleMenuModal.tsx
+++ b/src/components/Home/Modals/ArticleMenuModal.tsx
@@ -1,5 +1,6 @@
 import { homeActions } from "app/store/ducks/home/homeSlice";
 import { useAppDispatch } from "app/store/hooks";
+import useCopy from "hooks/useCopy";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import ModalCard from "styles/UI/ModalCard";
@@ -30,12 +31,10 @@ const ArticleMenuModalInner = styled.div`
 `;
 
 interface ArticleMenuModalProps {
-    isFollowing: boolean;
-    onUnfollow: () => void;
+    // isFollowing: boolean;
+    // onUnfollow: () => void;
     onModalOn: () => void;
     onModalOff: () => void;
-    onReportModalOn: () => void;
-    onShareWithModalOn: () => void;
 }
 
 const DUMMY_P_ID = "CWWCI-eINvr"; // 게시물 id
@@ -43,44 +42,13 @@ const DUMMY_P_ID = "CWWCI-eINvr"; // 게시물 id
 const DUMMY_BASE_URL = "https://www.instagram.com"; // 원래 root url: window.location.href
 
 const ArticleMenuModal = ({
-    isFollowing,
-    onUnfollow,
+    // isFollowing,
+    // onUnfollow,
     onModalOn,
     onModalOff,
-    onReportModalOn,
-    onShareWithModalOn,
 }: ArticleMenuModalProps) => {
     const dispatch = useAppDispatch();
-
-    const copyHandler = () => {
-        if (!document.queryCommandSupported("copy")) {
-            return alert("복사하기가 지원되지 않는 브라우저입니다.");
-        }
-        const textarea = document.createElement("textarea");
-        textarea.value = DUMMY_BASE_URL + "/p/" + DUMMY_P_ID;
-        textarea.style.position = "fixed";
-        textarea.style.top = "0";
-        textarea.style.left = "0";
-        // 포지션을 주지 않으면 복사 시 스크롤이 하단으로 이동
-
-        document.body.appendChild(textarea);
-        textarea.focus();
-        textarea.select();
-        document.execCommand("copy");
-        document.body.removeChild(textarea);
-        dispatch(homeActions.notificateIsCopied());
-        setTimeout(
-            () => dispatch(homeActions.closeIsCopiedNotification()),
-            8500,
-        );
-        // notification root 작성 후 복사 여부 알려주기
-        // dispatch(notificationActions.appear())
-    };
-
-    const reportClickHandler = () => {
-        onModalOff();
-        onReportModalOn();
-    };
+    const copyHandler = useCopy(DUMMY_BASE_URL + "/p/" + DUMMY_P_ID);
 
     return (
         <ModalCard
@@ -91,23 +59,39 @@ const ArticleMenuModal = ({
             <ArticleMenuModalInner>
                 <div
                     className="articleMenuModal-report"
-                    onClick={reportClickHandler}
+                    onClick={() =>
+                        dispatch(
+                            homeActions.startModal({
+                                activatedModal: "report",
+                            }),
+                        )
+                    }
                 >
                     신고
                 </div>
-                {isFollowing && (
+                {/* {isFollowing && (
                     <div
                         className="articleMenuModal-unfollow"
                         onClick={onUnfollow}
                     >
                         팔로우 취소
                     </div>
-                )}
+                )} */}
                 <div>
                     <Link to={`/`}>게시물로 이동</Link>
                     {/* p, tv 등 다양해서 일단 url은 보류 */}
                 </div>
-                <div onClick={onShareWithModalOn}>공유 대상...</div>
+                <div
+                    onClick={() =>
+                        dispatch(
+                            homeActions.startModal({
+                                activatedModal: "shareWith",
+                            }),
+                        )
+                    }
+                >
+                    공유 대상...
+                </div>
                 <div onClick={copyHandler}>링크 복사</div>
                 <div>퍼가기</div>
                 <div onClick={onModalOff}>취소</div>

--- a/src/components/Home/Modals/FollowingModal.tsx
+++ b/src/components/Home/Modals/FollowingModal.tsx
@@ -1,4 +1,3 @@
-import { homeActions } from "app/store/ducks/home/homeSlice";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
 import { useAppDispatch } from "app/store/hooks";
 import StoryCircle from "components/Common/StoryCircle";
@@ -58,8 +57,6 @@ const FollowingModal = ({
     const dispatch = useAppDispatch();
     const unFollowHandler = () => {
         // 언팔로우
-        // onUnfollow(); //dispatch, thunk로 해결
-        // onModalOff();
         dispatch(modalActions.resetModal());
     };
 

--- a/src/components/Home/Modals/FollowingModal.tsx
+++ b/src/components/Home/Modals/FollowingModal.tsx
@@ -1,4 +1,5 @@
 import { homeActions } from "app/store/ducks/home/homeSlice";
+import { modalActions } from "app/store/ducks/modal/modalSlice";
 import { useAppDispatch } from "app/store/hooks";
 import StoryCircle from "components/Common/StoryCircle";
 import styled from "styled-components";
@@ -59,7 +60,7 @@ const FollowingModal = ({
         // 언팔로우
         // onUnfollow(); //dispatch, thunk로 해결
         // onModalOff();
-        dispatch(homeActions.resetModal());
+        dispatch(modalActions.resetModal());
     };
 
     return (

--- a/src/components/Home/Modals/FollowingModal.tsx
+++ b/src/components/Home/Modals/FollowingModal.tsx
@@ -1,3 +1,5 @@
+import { homeActions } from "app/store/ducks/home/homeSlice";
+import { useAppDispatch } from "app/store/hooks";
 import StoryCircle from "components/Common/StoryCircle";
 import styled from "styled-components";
 import ModalCard from "styles/UI/ModalCard";
@@ -36,7 +38,7 @@ const FollowingModalInner = styled.div`
 `;
 
 interface FollowingModalProps {
-    onUnfollow: () => void;
+    // onUnfollow: () => void;
     onModalOn: () => void;
     onModalOff: () => void;
     username: string;
@@ -46,16 +48,18 @@ interface FollowingModalProps {
 const MODAL_CIRCLE_SIZE = 90 / 64;
 
 const FollowingModal = ({
-    onUnfollow,
+    // onUnfollow,
     onModalOn,
     onModalOff,
     username,
     avatarUrl,
 }: FollowingModalProps) => {
+    const dispatch = useAppDispatch();
     const unFollowHandler = () => {
         // 언팔로우
-        onUnfollow();
-        onModalOff();
+        // onUnfollow(); //dispatch, thunk로 해결
+        // onModalOff();
+        dispatch(homeActions.resetModal());
     };
 
     return (

--- a/src/components/Home/Modals/FollowingModal.tsx
+++ b/src/components/Home/Modals/FollowingModal.tsx
@@ -1,6 +1,8 @@
+import { postUnfollow } from "app/store/ducks/home/homThunk";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
 import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import StoryCircle from "components/Common/StoryCircle";
+import { token } from "Routes";
 import styled from "styled-components";
 import ModalCard from "styles/UI/ModalCard";
 
@@ -50,13 +52,16 @@ const FollowingModal = ({
     onModalOn,
     onModalOff,
 }: FollowingModalProps) => {
-    const { memberNickname, memberImageUrl } = useAppSelector(
+    const { memberNickname, memberUsername, memberImageUrl } = useAppSelector(
         ({ modal }) => modal,
     );
     const dispatch = useAppDispatch();
     const unFollowHandler = () => {
         // 언팔로우
-        dispatch(modalActions.resetModal());
+        const unFollowUser = async () => {
+            await dispatch(postUnfollow({ token, username: memberUsername }));
+        };
+        unFollowUser();
     };
 
     return (

--- a/src/components/Home/Modals/FollowingModal.tsx
+++ b/src/components/Home/Modals/FollowingModal.tsx
@@ -40,18 +40,13 @@ const FollowingModalInner = styled.div`
 `;
 
 interface FollowingModalProps {
-    // onUnfollow: () => void;
     onModalOn: () => void;
     onModalOff: () => void;
 }
 
 const MODAL_CIRCLE_SIZE = 90 / 64;
 
-const FollowingModal = ({
-    // onUnfollow,
-    onModalOn,
-    onModalOff,
-}: FollowingModalProps) => {
+const FollowingModal = ({ onModalOn, onModalOff }: FollowingModalProps) => {
     const { memberNickname, memberUsername, memberImageUrl } = useAppSelector(
         ({ modal }) => modal,
     );
@@ -62,6 +57,7 @@ const FollowingModal = ({
             await dispatch(postUnfollow({ token, username: memberUsername }));
         };
         unFollowUser();
+        onModalOff();
     };
 
     return (

--- a/src/components/Home/Modals/FollowingModal.tsx
+++ b/src/components/Home/Modals/FollowingModal.tsx
@@ -1,5 +1,5 @@
 import { modalActions } from "app/store/ducks/modal/modalSlice";
-import { useAppDispatch } from "app/store/hooks";
+import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import StoryCircle from "components/Common/StoryCircle";
 import styled from "styled-components";
 import ModalCard from "styles/UI/ModalCard";
@@ -41,8 +41,6 @@ interface FollowingModalProps {
     // onUnfollow: () => void;
     onModalOn: () => void;
     onModalOff: () => void;
-    username: string;
-    avatarUrl: string;
 }
 
 const MODAL_CIRCLE_SIZE = 90 / 64;
@@ -51,9 +49,10 @@ const FollowingModal = ({
     // onUnfollow,
     onModalOn,
     onModalOff,
-    username,
-    avatarUrl,
 }: FollowingModalProps) => {
+    const { memberNickname, memberImageUrl } = useAppSelector(
+        ({ modal }) => modal,
+    );
     const dispatch = useAppDispatch();
     const unFollowHandler = () => {
         // 언팔로우
@@ -69,12 +68,12 @@ const FollowingModal = ({
             <FollowingModalInner>
                 <StoryCircle
                     type="default"
-                    avatarUrl={avatarUrl}
-                    username={username}
+                    avatarUrl={memberImageUrl}
+                    username={memberNickname}
                     scale={MODAL_CIRCLE_SIZE}
                 />
                 <div className="followingModal-warning">
-                    @{username}님의 팔로우를 취소하시겠어요?
+                    @{memberNickname}님의 팔로우를 취소하시겠어요?
                 </div>
                 <div
                     className="followingModal-delete"

--- a/src/components/Home/Modals/HoverModal.tsx
+++ b/src/components/Home/Modals/HoverModal.tsx
@@ -8,7 +8,10 @@ import Username from "../../Common/Username";
 import sprite2 from "../../../assets/Images/sprite2.png";
 import useNumberSummary from "hooks/useNumberSummary";
 import Button from "styles/UI/Button";
-import { useAppSelector } from "app/store/hooks";
+import { useAppDispatch, useAppSelector } from "app/store/hooks";
+import { getMiniProfile } from "app/store/ducks/modal/modalThunk";
+import { modalActions } from "app/store/ducks/modal/modalSlice";
+import { token } from "Routes";
 
 const StyledHoverModalInner = styled.div`
     width: 100%;
@@ -108,23 +111,8 @@ interface HoverModalProps {
     // modalPosition?: DOMRect;
     onMouseEnter: () => void;
     onMouseLeave: () => void;
-    onFollowingModalOn: () => void;
-}
-
-interface UserSummaryProps {
-    avatarUrl: string;
-    verified: boolean;
-    isFollowing: boolean;
-    realName: string;
-    link?: string;
-    followingUsernames: string[]; // 내가 팔로우한 사람 중에 이 사람 팔로우한 사람.
-    articlesNum: number;
-    followersNum: number;
-    followsNum: number;
-    recentImgs: {
-        src: string;
-        param: string; // 나중에 수정
-    }[];
+    miniProfile: ModalType.MiniProfileProps;
+    // onFollowingModalOn: () => void;
 }
 
 const HoverModal = ({
@@ -134,53 +122,22 @@ const HoverModal = ({
     // modalPosition,
     onMouseEnter,
     onMouseLeave,
-    onFollowingModalOn,
-}: HoverModalProps) => {
-    const [userSummary, setUserSummary] = useState<UserSummaryProps>();
-    const articlesNumSummary = useNumberSummary(
-        userSummary ? userSummary.articlesNum : 0,
+    miniProfile,
+}: // onFollowingModalOn,
+HoverModalProps) => {
+    const { modalPosition } = useAppSelector(({ modal }) => modal);
+    const dispatch = useAppDispatch();
+
+    const postsNumSummary = useNumberSummary(
+        miniProfile ? miniProfile.memberPostsCount : 0,
     );
     const followersNumSummary = useNumberSummary(
-        userSummary ? userSummary.followersNum : 0,
+        miniProfile ? miniProfile.memberFollowersCount : 0,
     );
     const followsNumSummary = useNumberSummary(
-        userSummary ? userSummary.followsNum : 0,
-    );
-    const { modalPosition, memberNickname } = useAppSelector(
-        ({ modal }) => modal,
+        miniProfile ? miniProfile.memberFollowingsCount : 0,
     );
 
-    useEffect(() => {
-        // get username summary
-        const fetchedUserSummary = {
-            avatarUrl:
-                "https://images.unsplash.com/photo-1497316730643-415fac54a2af?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2000&q=80",
-            verified: true,
-            isFollowing: false,
-            realName: "Son HeungMin(손흥민)",
-            link: "https://linktr.ee/spursofficial",
-            followingUsernames: ["hwangheechan", "me"],
-            articlesNum: 11792,
-            followersNum: 11424642,
-            followsNum: 154,
-            recentImgs: [
-                {
-                    src: "https://images.unsplash.com/photo-1497316730643-415fac54a2af?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2000&q=80",
-                    param: "dsfds",
-                },
-                {
-                    src: "https://images.unsplash.com/photo-1497316730643-415fac54a2af?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2000&q=80",
-                    param: "hsgh",
-                },
-                {
-                    src: "https://images.unsplash.com/photo-1497316730643-415fac54a2af?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2000&q=80",
-                    param: "sdfhhjhj",
-                },
-            ],
-        };
-        setUserSummary(fetchedUserSummary);
-        // onFollowChange(fetchedUserSummary.isFollowing);
-    }, []);
     return (
         <ModalCard
             modalType="positioned"
@@ -188,47 +145,58 @@ const HoverModal = ({
             onModalOn={onMouseEnter}
             onModalOff={onMouseLeave}
         >
-            {userSummary && memberNickname && (
+            {miniProfile.memberName && (
                 <StyledHoverModalInner>
                     <div className="hoverModal-top">
-                        <Link to={`/${memberNickname}`}>
+                        <Link to={`/${miniProfile.memberName}`}>
                             <StoryCircle
                                 type="default"
-                                avatarUrl={userSummary.avatarUrl}
-                                username={memberNickname}
+                                avatarUrl={miniProfile.memberImage.imageUrl}
+                                username={miniProfile.memberName}
                                 scale={1}
                             />
                         </Link>
                         <div className="hoverModal-top-info">
                             <Link
-                                to={`/${memberNickname}`}
+                                to={`/${miniProfile.memberName}`}
                                 className="hoverModal-top-username"
                             >
-                                <Username>{memberNickname}</Username>
-                                {userSummary.verified && (
+                                <Username>{miniProfile.memberName}</Username>
+                                {/* {userSummary.verified && (
                                     <span className="hoverModal-top-verified">
                                         인증됨
                                     </span>
-                                )}
+                                )} */}
                             </Link>
                             <div className="hoverModal-top-realName">
-                                {userSummary.realName}
+                                {miniProfile.memberName}
+                                {/* 원래 진짜 이름 있어야 하는데 */}
                             </div>
-                            <a
-                                href={`${userSummary.link}`}
-                                target="_blank"
-                                rel="noreferrer"
-                                className="hoverModal-top-link"
-                            >
-                                {userSummary.link}
-                            </a>
-                            <div className="hoverModal-top-follwers">{`${userSummary.followingUsernames[0]}님 외 ${userSummary.followingUsernames.length}명이 팔로우합니다`}</div>
+                            {miniProfile.memberWebsite && (
+                                <a
+                                    href={`${miniProfile.memberWebsite}`}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="hoverModal-top-link"
+                                >
+                                    {miniProfile.memberWebsite}
+                                </a>
+                            )}
+                            <div className="hoverModal-top-follwers">
+                                {miniProfile.followingMemberFollow
+                                    ? `${
+                                          miniProfile.followingMemberFollow
+                                      }님 외 ${
+                                          miniProfile.memberFollowersCount - 1
+                                      }명이 팔로우합니다`
+                                    : `${miniProfile.memberFollowersCount}명이 팔로우합니다`}
+                            </div>
                         </div>
                     </div>
                     <div className="hoverModal-middle">
                         <div className="hoverModal-middle-articles">
                             <div>게시물</div>
-                            <div>{articlesNumSummary}</div>
+                            <div>{postsNumSummary}</div>
                         </div>
                         <div className="hoverModal-middle-followers">
                             <div>팔로워</div>
@@ -240,29 +208,40 @@ const HoverModal = ({
                         </div>
                     </div>
                     <div className="hoverModal-bottom">
-                        {userSummary.recentImgs.map((obj) => (
-                            <Link to={`/p/${obj.param}`} key={obj.param}>
-                                <img src={obj.src} alt={obj.param} />
+                        {miniProfile.memberPosts.map((obj) => (
+                            <Link to={`/p/${obj.postId}`} key={obj.postId}>
+                                <img
+                                    src={obj.postImageUrl}
+                                    alt={`${miniProfile.memberName}님의 최근 게시물`}
+                                />
                             </Link>
                         ))}
                     </div>
                     <div className="hoverModal-btns">
-                        {/* {isFollowing ? (
+                        {miniProfile.following ? (
                             <>
                                 <Link to="/direct/t/id">
                                     <Card>메세지 보내기</Card>
                                 </Link>
                                 <div>
-                                    <Card onClick={onFollowingModalOn}>
+                                    <Card
+                                        onClick={() => {
+                                            console.log("clicked");
+                                            dispatch(
+                                                modalActions.changeActivatedModal(
+                                                    "unfollowing",
+                                                ),
+                                            );
+                                        }}
+                                    >
                                         팔로잉
                                     </Card>
                                 </div>
                             </>
                         ) : (
-                            <Button onClick={() => onFollowChange(true)}>
-                                팔로우
-                            </Button>
-                        )} */}
+                            // <Button onClick={() => onFollowChange(true)}>
+                            <Button onClick={() => {}}>팔로우</Button>
+                        )}
                     </div>
                 </StyledHoverModalInner>
             )}

--- a/src/components/Home/Modals/HoverModal.tsx
+++ b/src/components/Home/Modals/HoverModal.tsx
@@ -245,7 +245,7 @@ const HoverModal = ({
                         ) : (
                             <Button onClick={followClickHandler}>
                                 {miniProfile.isLoading ? (
-                                    <Loading size={18} isInButtun={true} />
+                                    <Loading size={18} isInButton={true} />
                                 ) : (
                                     "팔로우"
                                 )}

--- a/src/components/Home/Modals/HoverModal.tsx
+++ b/src/components/Home/Modals/HoverModal.tsx
@@ -6,7 +6,7 @@ import Card from "styles/UI/Card";
 import ModalCard from "styles/UI/ModalCard";
 import Username from "../../Common/Username";
 import sprite2 from "../../../assets/Images/sprite2.png";
-import useNumberSummary from "Hooks/useNumberSummary";
+import useNumberSummary from "hooks/useNumberSummary";
 import Button from "styles/UI/Button";
 
 const StyledHoverModalInner = styled.div`

--- a/src/components/Home/Modals/HoverModal.tsx
+++ b/src/components/Home/Modals/HoverModal.tsx
@@ -1,5 +1,4 @@
 import StoryCircle from "components/Common/StoryCircle";
-import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import Card from "styles/UI/Card";
@@ -9,9 +8,7 @@ import sprite2 from "../../../assets/Images/sprite2.png";
 import useNumberSummary from "hooks/useNumberSummary";
 import Button from "styles/UI/Button";
 import { useAppDispatch, useAppSelector } from "app/store/hooks";
-import { getMiniProfile } from "app/store/ducks/modal/modalThunk";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
-import { token } from "Routes";
 
 const StyledHoverModalInner = styled.div`
     width: 100%;

--- a/src/components/Home/Modals/HoverModal.tsx
+++ b/src/components/Home/Modals/HoverModal.tsx
@@ -128,7 +128,6 @@ const HoverModal = ({
     miniProfile,
 }: // onFollowingModalOn,
 HoverModalProps) => {
-    const { modalPosition } = useAppSelector(({ modal }) => modal);
     const dispatch = useAppDispatch();
 
     const postsNumSummary = useNumberSummary(
@@ -153,7 +152,7 @@ HoverModalProps) => {
     return (
         <ModalCard
             modalType="positioned"
-            modalPosition={modalPosition}
+            modalPosition={miniProfile.modalPosition}
             onModalOn={onMouseEnter}
             onModalOff={onMouseLeave}
         >

--- a/src/components/Home/Modals/HoverModal.tsx
+++ b/src/components/Home/Modals/HoverModal.tsx
@@ -9,6 +9,9 @@ import useNumberSummary from "hooks/useNumberSummary";
 import Button from "styles/UI/Button";
 import { useAppDispatch, useAppSelector } from "app/store/hooks";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
+import Loading from "components/Common/Loading";
+import { token } from "Routes";
+import { postFollow } from "app/store/ducks/home/homThunk";
 
 const StyledHoverModalInner = styled.div`
     width: 100%;
@@ -98,6 +101,9 @@ const StyledHoverModalInner = styled.div`
                 text-align: center;
             }
         }
+        & > button > div {
+            padding: 0;
+        }
     }
 `;
 
@@ -108,7 +114,7 @@ interface HoverModalProps {
     // modalPosition?: DOMRect;
     onMouseEnter: () => void;
     onMouseLeave: () => void;
-    miniProfile: ModalType.MiniProfileProps;
+    miniProfile: ModalType.MiniProfileStateProps;
     // onFollowingModalOn: () => void;
 }
 
@@ -134,6 +140,15 @@ HoverModalProps) => {
     const followsNumSummary = useNumberSummary(
         miniProfile ? miniProfile.memberFollowingsCount : 0,
     );
+
+    const followClickHandler = () => {
+        const followUser = async () => {
+            await dispatch(
+                postFollow({ token, username: miniProfile.memberUsername }),
+            );
+        };
+        followUser();
+    };
 
     return (
         <ModalCard
@@ -230,13 +245,22 @@ HoverModalProps) => {
                                             )
                                         }
                                     >
-                                        팔로잉
+                                        {miniProfile.isLoading ? (
+                                            <Loading size={18} />
+                                        ) : (
+                                            "팔로잉"
+                                        )}
                                     </Card>
                                 </div>
                             </>
                         ) : (
-                            // <Button onClick={() => onFollowChange(true)}>
-                            <Button onClick={() => {}}>팔로우</Button>
+                            <Button onClick={followClickHandler}>
+                                {miniProfile.isLoading ? (
+                                    <Loading size={18} isInButtun={true} />
+                                ) : (
+                                    "팔로우"
+                                )}
+                            </Button>
                         )}
                     </div>
                 </StyledHoverModalInner>

--- a/src/components/Home/Modals/HoverModal.tsx
+++ b/src/components/Home/Modals/HoverModal.tsx
@@ -147,7 +147,7 @@ const HoverModal = ({
         userSummary ? userSummary.followsNum : 0,
     );
     const { modalPosition, memberNickname } = useAppSelector(
-        ({ home }) => home.modalDTOs,
+        ({ modal }) => modal,
     );
 
     useEffect(() => {

--- a/src/components/Home/Modals/HoverModal.tsx
+++ b/src/components/Home/Modals/HoverModal.tsx
@@ -222,14 +222,13 @@ HoverModalProps) => {
                                 </Link>
                                 <div>
                                     <Card
-                                        onClick={() => {
-                                            console.log("clicked");
+                                        onClick={() =>
                                             dispatch(
                                                 modalActions.changeActivatedModal(
                                                     "unfollowing",
                                                 ),
-                                            );
-                                        }}
+                                            )
+                                        }
                                     >
                                         팔로잉
                                     </Card>

--- a/src/components/Home/Modals/HoverModal.tsx
+++ b/src/components/Home/Modals/HoverModal.tsx
@@ -108,26 +108,16 @@ const StyledHoverModalInner = styled.div`
 `;
 
 interface HoverModalProps {
-    // isFollowing?: boolean;
-    // onFollowChange: (a: boolean) => void;
-    // username: string;
-    // modalPosition?: DOMRect;
     onMouseEnter: () => void;
     onMouseLeave: () => void;
     miniProfile: ModalType.MiniProfileStateProps;
-    // onFollowingModalOn: () => void;
 }
 
 const HoverModal = ({
-    // isFollowing,
-    // onFollowChange,
-    // username,
-    // modalPosition,
     onMouseEnter,
     onMouseLeave,
     miniProfile,
-}: // onFollowingModalOn,
-HoverModalProps) => {
+}: HoverModalProps) => {
     const dispatch = useAppDispatch();
 
     const postsNumSummary = useNumberSummary(

--- a/src/components/Home/Modals/HoverModal.tsx
+++ b/src/components/Home/Modals/HoverModal.tsx
@@ -8,6 +8,7 @@ import Username from "../../Common/Username";
 import sprite2 from "../../../assets/Images/sprite2.png";
 import useNumberSummary from "hooks/useNumberSummary";
 import Button from "styles/UI/Button";
+import { useAppSelector } from "app/store/hooks";
 
 const StyledHoverModalInner = styled.div`
     width: 100%;
@@ -101,10 +102,10 @@ const StyledHoverModalInner = styled.div`
 `;
 
 interface HoverModalProps {
-    isFollowing?: boolean;
-    onFollowChange: (a: boolean) => void;
-    username: string;
-    modalPosition?: DOMRect;
+    // isFollowing?: boolean;
+    // onFollowChange: (a: boolean) => void;
+    // username: string;
+    // modalPosition?: DOMRect;
     onMouseEnter: () => void;
     onMouseLeave: () => void;
     onFollowingModalOn: () => void;
@@ -127,10 +128,10 @@ interface UserSummaryProps {
 }
 
 const HoverModal = ({
-    isFollowing,
-    onFollowChange,
-    username,
-    modalPosition,
+    // isFollowing,
+    // onFollowChange,
+    // username,
+    // modalPosition,
     onMouseEnter,
     onMouseLeave,
     onFollowingModalOn,
@@ -145,6 +146,10 @@ const HoverModal = ({
     const followsNumSummary = useNumberSummary(
         userSummary ? userSummary.followsNum : 0,
     );
+    const { modalPosition, memberNickname } = useAppSelector(
+        ({ home }) => home.modalDTOs,
+    );
+
     useEffect(() => {
         // get username summary
         const fetchedUserSummary = {
@@ -183,23 +188,23 @@ const HoverModal = ({
             onModalOn={onMouseEnter}
             onModalOff={onMouseLeave}
         >
-            {userSummary && (
+            {userSummary && memberNickname && (
                 <StyledHoverModalInner>
                     <div className="hoverModal-top">
-                        <Link to={`/${username}`}>
+                        <Link to={`/${memberNickname}`}>
                             <StoryCircle
                                 type="default"
                                 avatarUrl={userSummary.avatarUrl}
-                                username={username}
+                                username={memberNickname}
                                 scale={1}
                             />
                         </Link>
                         <div className="hoverModal-top-info">
                             <Link
-                                to={`/${username}`}
+                                to={`/${memberNickname}`}
                                 className="hoverModal-top-username"
                             >
-                                <Username>{username}</Username>
+                                <Username>{memberNickname}</Username>
                                 {userSummary.verified && (
                                     <span className="hoverModal-top-verified">
                                         인증됨
@@ -242,9 +247,8 @@ const HoverModal = ({
                         ))}
                     </div>
                     <div className="hoverModal-btns">
-                        {isFollowing ? (
+                        {/* {isFollowing ? (
                             <>
-                                {/* 이 아이디가 어떤 id인지 모르겠음 */}
                                 <Link to="/direct/t/id">
                                     <Card>메세지 보내기</Card>
                                 </Link>
@@ -258,7 +262,7 @@ const HoverModal = ({
                             <Button onClick={() => onFollowChange(true)}>
                                 팔로우
                             </Button>
-                        )}
+                        )} */}
                     </div>
                 </StyledHoverModalInner>
             )}

--- a/src/components/Home/Modals/SharerWithModal.tsx
+++ b/src/components/Home/Modals/SharerWithModal.tsx
@@ -4,6 +4,7 @@ import ModalHeader from "./ModalHeader";
 import direct from "../../../assets/Images/direct.png";
 import sprite3 from "../../../assets/Images/sprite3.png";
 import useCopy from "hooks/useCopy";
+import { useAppSelector } from "app/store/hooks";
 
 const ShareWithModalInner = styled.div`
     .shareWithModal-options {
@@ -83,7 +84,7 @@ const ShareWithModalInner = styled.div`
 interface ShareWithModalProps {
     onModalOn: () => void;
     onModalOff: () => void;
-    username: string;
+    // username: string;
 }
 
 const DUMMY_P_ID = "CWWCI-eINvr"; // 게시물 id
@@ -96,9 +97,10 @@ const DUMMY_BASE_URL = "https://www.instagram.com"; // 원래 root url: window.l
 const ShareWithModal = ({
     onModalOn,
     onModalOff,
-    username,
-}: ShareWithModalProps) => {
+}: // username, // appselector를 통해 가져오면 됨
+ShareWithModalProps) => {
     const copyHandler = useCopy(DUMMY_BASE_URL + "/p/" + DUMMY_P_ID);
+    const { memberNickname } = useAppSelector(({ home }) => home.modalDTOs);
 
     return (
         <ModalCard
@@ -159,7 +161,7 @@ const ShareWithModal = ({
                     </a>
                     <a
                         className="shareWithModal-email"
-                        href={`mailto:?subject=@${username}님의 이 인스타그램 게시물 보기&body=@${username}님의 이 인스타그램 게시물 보기 %20${
+                        href={`mailto:?subject=@${memberNickname}님의 이 인스타그램 게시물 보기&body=@${memberNickname}님의 이 인스타그램 게시물 보기 %20${
                             DUMMY_BASE_URL + "/p/" + DUMMY_P_ID
                         }%3Futm_source%3Dig_web_button_share_sheet`}
                         target="_top"

--- a/src/components/Home/Modals/SharerWithModal.tsx
+++ b/src/components/Home/Modals/SharerWithModal.tsx
@@ -87,20 +87,14 @@ interface ShareWithModalProps {
     // username: string;
 }
 
-const DUMMY_P_ID = "CWWCI-eINvr"; // 게시물 id
-
 const DUMMY_BASE_URL = "https://www.instagram.com"; // 원래 root url: window.location.href
 
 // 위 두 DUMMY 데이터로 공유 기능을 임시 구현하였습니다.
 // 참고 url: https://developers.facebook.com/docs/plugins/share-button?locale=ko_KR
 
-const ShareWithModal = ({
-    onModalOn,
-    onModalOff,
-}: // username, // appselector를 통해 가져오면 됨
-ShareWithModalProps) => {
-    const copyHandler = useCopy(DUMMY_BASE_URL + "/p/" + DUMMY_P_ID);
-    const { memberNickname } = useAppSelector(({ modal }) => modal);
+const ShareWithModal = ({ onModalOn, onModalOff }: ShareWithModalProps) => {
+    const { memberNickname, postId } = useAppSelector(({ modal }) => modal);
+    const copyHandler = useCopy(DUMMY_BASE_URL + "/p/" + postId);
 
     return (
         <ModalCard
@@ -121,7 +115,7 @@ ShareWithModalProps) => {
                     <a
                         className="shareWithModal-facebook"
                         href={`https://www.facebook.com/sharer/sharer.php?kid_directed_site=0&sdk=joey&u=${
-                            DUMMY_BASE_URL + "/p/" + DUMMY_P_ID
+                            DUMMY_BASE_URL + "/p/" + postId
                         }&display=popup&ref=plugin&src=share_button`}
                         target="_blank"
                         rel="noreferrer"
@@ -134,7 +128,7 @@ ShareWithModalProps) => {
                     <a
                         className="shareWithModal-messenger"
                         href={`https://www.facebook.com/sharer/sharer.php?kid_directed_site=0&sdk=joey&u=${
-                            DUMMY_BASE_URL + "/p/" + DUMMY_P_ID
+                            DUMMY_BASE_URL + "/p/" + postId
                         }&display=popup&ref=plugin&src=share_button`}
                         target="_blank"
                         rel="noreferrer"
@@ -148,7 +142,7 @@ ShareWithModalProps) => {
                     <a
                         className="shareWithModal-twitter"
                         href={`https://twitter.com/share?text=@님의 이 instagram 게시물 보기&url=${
-                            DUMMY_BASE_URL + "/p/" + DUMMY_P_ID
+                            DUMMY_BASE_URL + "/p/" + postId
                         }%3Futm_source%3Dig_web_button_share_sheet
                     `}
                         target="_blank"
@@ -162,7 +156,7 @@ ShareWithModalProps) => {
                     <a
                         className="shareWithModal-email"
                         href={`mailto:?subject=@${memberNickname}님의 이 인스타그램 게시물 보기&body=@${memberNickname}님의 이 인스타그램 게시물 보기 %20${
-                            DUMMY_BASE_URL + "/p/" + DUMMY_P_ID
+                            DUMMY_BASE_URL + "/p/" + postId
                         }%3Futm_source%3Dig_web_button_share_sheet`}
                         target="_top"
                     >

--- a/src/components/Home/Modals/SharerWithModal.tsx
+++ b/src/components/Home/Modals/SharerWithModal.tsx
@@ -100,7 +100,7 @@ const ShareWithModal = ({
 }: // username, // appselector를 통해 가져오면 됨
 ShareWithModalProps) => {
     const copyHandler = useCopy(DUMMY_BASE_URL + "/p/" + DUMMY_P_ID);
-    const memberNickname = useAppSelector(({ modal }) => modal.memberNickname);
+    const { memberNickname } = useAppSelector(({ modal }) => modal);
 
     return (
         <ModalCard

--- a/src/components/Home/Modals/SharerWithModal.tsx
+++ b/src/components/Home/Modals/SharerWithModal.tsx
@@ -3,7 +3,7 @@ import ModalCard from "styles/UI/ModalCard";
 import ModalHeader from "./ModalHeader";
 import direct from "../../../assets/Images/direct.png";
 import sprite3 from "../../../assets/Images/sprite3.png";
-import useCopy from "Hooks/useCopy";
+import useCopy from "hooks/useCopy";
 
 const ShareWithModalInner = styled.div`
     .shareWithModal-options {

--- a/src/components/Home/Modals/SharerWithModal.tsx
+++ b/src/components/Home/Modals/SharerWithModal.tsx
@@ -100,7 +100,7 @@ const ShareWithModal = ({
 }: // username, // appselector를 통해 가져오면 됨
 ShareWithModalProps) => {
     const copyHandler = useCopy(DUMMY_BASE_URL + "/p/" + DUMMY_P_ID);
-    const { memberNickname } = useAppSelector(({ home }) => home.modalDTOs);
+    const memberNickname = useAppSelector(({ modal }) => modal.memberNickname);
 
     return (
         <ModalCard

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -35,26 +35,18 @@ const Layout = styled.div`
 const Home = () => {
     const {
         home: { isCopiedNotification },
-        modal: {
-            activatedModal,
-            modalPosition,
-            memberNickname,
-            memberUsername,
-            memberImageUrl,
-            postId,
-        },
+        modal: { activatedModal, memberNickname, postId, miniProfile },
     } = useAppSelector((state) => state);
 
     const dispatch = useAppDispatch();
 
-    // const mouseEnterHandler = (
-    //     event:
-    //         | React.MouseEvent<HTMLSpanElement>
-    //         | React.MouseEvent<HTMLDivElement>,
-    // ) => {
-    //     setModalPositionObj(event?.currentTarget.getBoundingClientRect());
-    //     setIsHoverModalActivated(true);
-    // };
+    const hoverModalMouseEnterHandler = () => {
+        dispatch(modalActions.mouseOnHoverModal());
+    };
+    const hoverModalMouseLeaveHandler = () => {
+        dispatch(modalActions.mouseNotOnHoverModal());
+        setTimeout(() => dispatch(modalActions.checkMouseOnHoverModal()), 500);
+    };
 
     return (
         <Layout>
@@ -66,64 +58,27 @@ const Home = () => {
             {isCopiedNotification && (
                 <Notification text="링크를 클립보드에 복사했습니다." />
             )}
-            {activatedModal === "hover" && (
+            {miniProfile && (
                 <HoverModal
-                    // isFollowing={isFollowing}
-                    // onFollowChange={(a: boolean) => setIsFollowing(a)}
-                    // username={memberNickname}
-                    // modalPosition={modalPositionObj}
-                    onMouseEnter={() =>
-                        dispatch(
-                            modalActions.startModal({
-                                activatedModal: "hover",
-                                memberNickname,
-                                memberUsername,
-                                modalPosition,
-                            }),
-                        )
-                    }
-                    onMouseLeave={() => dispatch(modalActions.resetModal())}
-                    onFollowingModalOn={() =>
-                        dispatch(
-                            modalActions.startModal({
-                                activatedModal: "unfollowing",
-                                memberImageUrl,
-                            }),
-                        )
-                    }
+                    onMouseEnter={hoverModalMouseEnterHandler}
+                    onMouseLeave={hoverModalMouseLeaveHandler}
+                    miniProfile={miniProfile}
                 />
             )}
-            {activatedModal === "unfollowing" &&
-                memberNickname &&
-                memberImageUrl && (
-                    <FollowingModal
-                        // onUnfollow={() => setIsFollowing(false)}
-                        onModalOn={() =>
-                            dispatch(
-                                modalActions.startModal({
-                                    activatedModal: "unfollowing",
-                                    memberNickname,
-                                    memberImageUrl,
-                                }),
-                            )
-                        }
-                        onModalOff={() => dispatch(modalActions.resetModal())}
-                        username={memberNickname}
-                        avatarUrl={memberImageUrl}
-                    />
-                )}
+            {activatedModal === "unfollowing" && (
+                <FollowingModal
+                    onModalOn={() => {
+                        dispatch(modalActions.maintainModalon("unfollowing"));
+                    }}
+                    onModalOff={() => dispatch(modalActions.resetModal())}
+                />
+            )}
             {activatedModal === "articleMenu" && memberNickname && postId && (
                 <ArticleMenuModal
                     // isFollowing={isFollowing} 팔로우한 사람의 게시물만 보니까 당연히 처음엔 true
                     // onUnfollow={unfollowHandler}
                     onModalOn={() =>
-                        dispatch(
-                            modalActions.startModal({
-                                activatedModal: "articleMenu",
-                                memberNickname,
-                                postId,
-                            }),
-                        )
+                        dispatch(modalActions.maintainModalon("articleMenu"))
                     }
                     onModalOff={() => dispatch(modalActions.resetModal())}
                 />
@@ -132,11 +87,7 @@ const Home = () => {
             {activatedModal === "report" && (
                 <ReportModal
                     onModalOn={() =>
-                        dispatch(
-                            modalActions.startModal({
-                                activatedModal: "report",
-                            }),
-                        )
+                        dispatch(modalActions.maintainModalon("report"))
                     }
                     onModalOff={() => dispatch(modalActions.resetModal())}
                 />
@@ -144,11 +95,7 @@ const Home = () => {
             {activatedModal === "shareWith" && (
                 <ShareWithModal
                     onModalOn={() =>
-                        dispatch(
-                            modalActions.startModal({
-                                activatedModal: "shareWith",
-                            }),
-                        )
+                        dispatch(modalActions.maintainModalon("shareWith"))
                     }
                     onModalOff={() => dispatch(modalActions.resetModal())}
                 />

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -39,6 +39,7 @@ const Home = () => {
             activatedModal,
             modalPosition,
             memberNickname,
+            memberUsername,
             memberImageUrl,
             postId,
         },
@@ -76,6 +77,7 @@ const Home = () => {
                             modalActions.startModal({
                                 activatedModal: "hover",
                                 memberNickname,
+                                memberUsername,
                                 modalPosition,
                             }),
                         )

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -75,8 +75,6 @@ const Home = () => {
             )}
             {activatedModal === "articleMenu" && memberNickname && postId && (
                 <ArticleMenuModal
-                    // isFollowing={isFollowing} 팔로우한 사람의 게시물만 보니까 당연히 처음엔 true
-                    // onUnfollow={unfollowHandler}
                     onModalOn={() =>
                         dispatch(modalActions.maintainModalon("articleMenu"))
                     }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -3,7 +3,13 @@ import HomeAside from "components/Home/HomeAside";
 import HomeStories from "components/Home/HomeStories";
 import HomeSection from "components/Home/HomeSection";
 import Notification from "styles/UI/Notification";
-import { useAppSelector } from "app/store/hooks";
+import { useAppDispatch, useAppSelector } from "app/store/hooks";
+import HoverModal from "components/Home/Modals/HoverModal";
+import FollowingModal from "components/Home/Modals/FollowingModal";
+import ArticleMenuModal from "components/Home/Modals/ArticleMenuModal";
+import ReportModal from "components/Home/Modals/ReportModal";
+import ShareWithModal from "components/Home/Modals/SharerWithModal";
+import { homeActions } from "app/store/ducks/home/homeSlice";
 
 const Layout = styled.div`
     padding-top: 30px;
@@ -27,9 +33,27 @@ const Layout = styled.div`
 `;
 
 const Home = () => {
-    const isCopiedNotification = useAppSelector(
-        (state) => state.home.isCopiedNotification,
-    );
+    const {
+        isCopiedNotification,
+        modalDTOs: {
+            activatedModal,
+            modalPosition,
+            memberNickname,
+            memberImageUrl,
+            postId,
+        },
+    } = useAppSelector((state) => state.home);
+
+    const dispatch = useAppDispatch();
+
+    // const mouseEnterHandler = (
+    //     event:
+    //         | React.MouseEvent<HTMLSpanElement>
+    //         | React.MouseEvent<HTMLDivElement>,
+    // ) => {
+    //     setModalPositionObj(event?.currentTarget.getBoundingClientRect());
+    //     setIsHoverModalActivated(true);
+    // };
 
     return (
         <Layout>
@@ -40,6 +64,107 @@ const Home = () => {
             <HomeAside />
             {isCopiedNotification && (
                 <Notification text="링크를 클립보드에 복사했습니다." />
+            )}
+            {activatedModal === "hover" && (
+                <HoverModal
+                    // isFollowing={isFollowing}
+                    // onFollowChange={(a: boolean) => setIsFollowing(a)}
+                    // username={memberNickname}
+                    // modalPosition={modalPositionObj}
+                    onMouseEnter={() =>
+                        dispatch(
+                            homeActions.startModal({
+                                activatedModal: "hover",
+                                memberNickname,
+                                modalPosition,
+                            }),
+                        )
+                    }
+                    onMouseLeave={() => dispatch(homeActions.resetModal())}
+                    onFollowingModalOn={() =>
+                        dispatch(
+                            homeActions.startModal({
+                                activatedModal: "unfollowing",
+                                memberImageUrl,
+                            }),
+                        )
+                    }
+                />
+            )}
+            {activatedModal === "unfollowing" &&
+                memberNickname &&
+                memberImageUrl && (
+                    <FollowingModal
+                        // onUnfollow={() => setIsFollowing(false)}
+                        onModalOn={() =>
+                            dispatch(
+                                homeActions.startModal({
+                                    activatedModal: "unfollowing",
+                                    memberNickname,
+                                    memberImageUrl,
+                                }),
+                            )
+                        }
+                        onModalOff={() => dispatch(homeActions.resetModal())}
+                        username={memberNickname}
+                        avatarUrl={memberImageUrl}
+                    />
+                )}
+            {activatedModal === "articleMenu" && memberNickname && postId && (
+                <ArticleMenuModal
+                    // isFollowing={isFollowing} 팔로우한 사람의 게시물만 보니까 당연히 처음엔 true
+                    // onUnfollow={unfollowHandler}
+                    onModalOn={() =>
+                        dispatch(
+                            homeActions.startModal({
+                                activatedModal: "articleMenu",
+                                memberNickname,
+                                postId,
+                            }),
+                        )
+                    }
+                    onModalOff={() => dispatch(homeActions.resetModal())}
+                    // onReportModalOn={() =>
+                    //     dispatch(
+                    //         homeActions.startModal({
+                    //             activatedModal: "report", // 게시물, 등등은 이미 articleMenu에서 결정
+                    //         }),
+                    //     )
+                    // }
+                    // onShareWithModalOn={() =>
+                    //     dispatch(
+                    //         homeActions.startModal({
+                    //             activatedModal: "shareWith", // 게시물, 등등은 이미 articleMenu에서 결정
+                    //         }),
+                    //     )
+                    // }
+                />
+            )}
+            {/* 아래 두 모달은 이전 모달을 거쳐야 하므로 필요없는 data는 action에 담지 않음 */}
+            {activatedModal === "report" && (
+                <ReportModal
+                    // onModalOn={() => setIsReportModalActivated(true)}
+                    onModalOn={() =>
+                        dispatch(
+                            homeActions.startModal({
+                                activatedModal: "report",
+                            }),
+                        )
+                    }
+                    onModalOff={() => dispatch(homeActions.resetModal())}
+                />
+            )}
+            {activatedModal === "shareWith" && (
+                <ShareWithModal
+                    onModalOn={() =>
+                        dispatch(
+                            homeActions.startModal({
+                                activatedModal: "shareWith",
+                            }),
+                        )
+                    }
+                    onModalOff={() => dispatch(homeActions.resetModal())}
+                />
             )}
         </Layout>
     );

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -9,7 +9,6 @@ import FollowingModal from "components/Home/Modals/FollowingModal";
 import ArticleMenuModal from "components/Home/Modals/ArticleMenuModal";
 import ReportModal from "components/Home/Modals/ReportModal";
 import ShareWithModal from "components/Home/Modals/SharerWithModal";
-import { homeActions } from "app/store/ducks/home/homeSlice";
 import { modalActions } from "app/store/ducks/modal/modalSlice";
 
 const Layout = styled.div`
@@ -125,26 +124,11 @@ const Home = () => {
                         )
                     }
                     onModalOff={() => dispatch(modalActions.resetModal())}
-                    // onReportModalOn={() =>
-                    //     dispatch(
-                    //         homeActions.startModal({
-                    //             activatedModal: "report", // 게시물, 등등은 이미 articleMenu에서 결정
-                    //         }),
-                    //     )
-                    // }
-                    // onShareWithModalOn={() =>
-                    //     dispatch(
-                    //         homeActions.startModal({
-                    //             activatedModal: "shareWith", // 게시물, 등등은 이미 articleMenu에서 결정
-                    //         }),
-                    //     )
-                    // }
                 />
             )}
             {/* 아래 두 모달은 이전 모달을 거쳐야 하므로 필요없는 data는 action에 담지 않음 */}
             {activatedModal === "report" && (
                 <ReportModal
-                    // onModalOn={() => setIsReportModalActivated(true)}
                     onModalOn={() =>
                         dispatch(
                             modalActions.startModal({

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -10,6 +10,7 @@ import ArticleMenuModal from "components/Home/Modals/ArticleMenuModal";
 import ReportModal from "components/Home/Modals/ReportModal";
 import ShareWithModal from "components/Home/Modals/SharerWithModal";
 import { homeActions } from "app/store/ducks/home/homeSlice";
+import { modalActions } from "app/store/ducks/modal/modalSlice";
 
 const Layout = styled.div`
     padding-top: 30px;
@@ -34,15 +35,15 @@ const Layout = styled.div`
 
 const Home = () => {
     const {
-        isCopiedNotification,
-        modalDTOs: {
+        home: { isCopiedNotification },
+        modal: {
             activatedModal,
             modalPosition,
             memberNickname,
             memberImageUrl,
             postId,
         },
-    } = useAppSelector((state) => state.home);
+    } = useAppSelector((state) => state);
 
     const dispatch = useAppDispatch();
 
@@ -73,17 +74,17 @@ const Home = () => {
                     // modalPosition={modalPositionObj}
                     onMouseEnter={() =>
                         dispatch(
-                            homeActions.startModal({
+                            modalActions.startModal({
                                 activatedModal: "hover",
                                 memberNickname,
                                 modalPosition,
                             }),
                         )
                     }
-                    onMouseLeave={() => dispatch(homeActions.resetModal())}
+                    onMouseLeave={() => dispatch(modalActions.resetModal())}
                     onFollowingModalOn={() =>
                         dispatch(
-                            homeActions.startModal({
+                            modalActions.startModal({
                                 activatedModal: "unfollowing",
                                 memberImageUrl,
                             }),
@@ -98,14 +99,14 @@ const Home = () => {
                         // onUnfollow={() => setIsFollowing(false)}
                         onModalOn={() =>
                             dispatch(
-                                homeActions.startModal({
+                                modalActions.startModal({
                                     activatedModal: "unfollowing",
                                     memberNickname,
                                     memberImageUrl,
                                 }),
                             )
                         }
-                        onModalOff={() => dispatch(homeActions.resetModal())}
+                        onModalOff={() => dispatch(modalActions.resetModal())}
                         username={memberNickname}
                         avatarUrl={memberImageUrl}
                     />
@@ -116,14 +117,14 @@ const Home = () => {
                     // onUnfollow={unfollowHandler}
                     onModalOn={() =>
                         dispatch(
-                            homeActions.startModal({
+                            modalActions.startModal({
                                 activatedModal: "articleMenu",
                                 memberNickname,
                                 postId,
                             }),
                         )
                     }
-                    onModalOff={() => dispatch(homeActions.resetModal())}
+                    onModalOff={() => dispatch(modalActions.resetModal())}
                     // onReportModalOn={() =>
                     //     dispatch(
                     //         homeActions.startModal({
@@ -146,24 +147,24 @@ const Home = () => {
                     // onModalOn={() => setIsReportModalActivated(true)}
                     onModalOn={() =>
                         dispatch(
-                            homeActions.startModal({
+                            modalActions.startModal({
                                 activatedModal: "report",
                             }),
                         )
                     }
-                    onModalOff={() => dispatch(homeActions.resetModal())}
+                    onModalOff={() => dispatch(modalActions.resetModal())}
                 />
             )}
             {activatedModal === "shareWith" && (
                 <ShareWithModal
                     onModalOn={() =>
                         dispatch(
-                            homeActions.startModal({
+                            modalActions.startModal({
                                 activatedModal: "shareWith",
                             }),
                         )
                     }
-                    onModalOff={() => dispatch(homeActions.resetModal())}
+                    onModalOff={() => dispatch(modalActions.resetModal())}
                 />
             )}
         </Layout>

--- a/src/styles/UI/ModalCard/ModalCard.tsx
+++ b/src/styles/UI/ModalCard/ModalCard.tsx
@@ -1,4 +1,3 @@
-import { HomeType } from "@type";
 import React, { useMemo, useRef } from "react";
 import ReactDOM from "react-dom";
 import styled from "styled-components";

--- a/src/styles/UI/ModalCard/ModalCard.tsx
+++ b/src/styles/UI/ModalCard/ModalCard.tsx
@@ -55,7 +55,7 @@ const StyledBackDrop = styled.div`
 
 interface ModalProps {
     modalType?: "positioned" | "withBackDrop";
-    modalPosition?: HomeType.ModalPositionProps;
+    modalPosition?: ModalType.ModalPositionProps;
     onModalOn: () => void;
     onModalOff: () => void;
     children: React.ReactNode;

--- a/src/styles/UI/ModalCard/ModalCard.tsx
+++ b/src/styles/UI/ModalCard/ModalCard.tsx
@@ -12,7 +12,7 @@ interface PositionedModal extends CardProps {
 
 const StyledPositionedModal = styled(Card)<PositionedModal>`
     position: absolute;
-    z-index: 101;
+    z-index: 100;
     width: 390px;
     top: ${(props) => props.top + "px"};
     left: ${(props) => props.left + "px"};

--- a/src/styles/UI/ModalCard/ModalCard.tsx
+++ b/src/styles/UI/ModalCard/ModalCard.tsx
@@ -1,3 +1,4 @@
+import { HomeType } from "@type";
 import React, { useMemo, useRef } from "react";
 import ReactDOM from "react-dom";
 import styled from "styled-components";
@@ -55,7 +56,7 @@ const StyledBackDrop = styled.div`
 
 interface ModalProps {
     modalType?: "positioned" | "withBackDrop";
-    modalPosition?: DOMRect;
+    modalPosition?: HomeType.ModalPositionProps;
     onModalOn: () => void;
     onModalOff: () => void;
     children: React.ReactNode;


### PR DESCRIPTION
미니프로필 정보를 access token, username을 통해 받아와 기존 `HoverModal`에 적용합니다.

- [x] 완성된 api가 배포된 이후 response에서 가져올 data의 타입 선언
- [x] 기존 더미데이터로 구성된 `HoverModal`에 response data를 miniProfile state에 담아 적용
- [x] hoverModal을 호출하는 컴포넌트(`ArticleHeader`, `ArticleMain`)에서 해당 thunk를 dispatch(기존: useState)
