### PR TITLE
fix: 카테고리 변할때마다 배열 초기화

### DIFF
--- a/src/app/store/ducks/profile/profileSlice.ts
+++ b/src/app/store/ducks/profile/profileSlice.ts
@@ -32,6 +32,7 @@ const profileSlice = createSlice({
             action: PayloadAction<Profile.currentCategoryType>,
         ) => {
             state.currentCategory = action.payload;
+            state.posts = [];
         },
         increaseExtraPostPage: (state) => {
             state.extraPostPage++;

--- a/src/app/store/ducks/profile/profileSlice.ts
+++ b/src/app/store/ducks/profile/profileSlice.ts
@@ -32,7 +32,7 @@ const profileSlice = createSlice({
             action: PayloadAction<Profile.currentCategoryType>,
         ) => {
             state.currentCategory = action.payload;
-            state.posts = [];
+            if (state.currentCategory !== action.payload) state.posts = [];
         },
         increaseExtraPostPage: (state) => {
             state.extraPostPage++;


### PR DESCRIPTION
## 개요
- 카테고리 변할때마다 배열을 초기화 해서 이전 카테고리의 해당하는 Posts 들이 리셋되도록함

## 작업사항

-   redux 에서 처리

## 주요 변경 로직

-   내용을 적어주세요.
