### PR TITLE
[비밀번호 재설정] api 연결 & 처리 

### DIFF
--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -135,6 +135,11 @@ declare module AuthType {
     interface resetPasswordState {
         email?: string;
     }
+
+    type resetPasswordQuery = {
+        username: string;
+        code: string;
+    };
 }
 
 declare module HomeType {

--- a/src/app/store/ducks/auth/authSlice.ts
+++ b/src/app/store/ducks/auth/authSlice.ts
@@ -1,6 +1,12 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { FormState } from "./authThunk.type";
-import { getUserInfo, signIn, resetPassword } from "./authThunk";
+import {
+    getUserInfo,
+    signIn,
+    resetPassword,
+    checkCurrentURL,
+    signInUseCode,
+} from "./authThunk";
 import { setAccessTokenInAxiosHeaders } from "customAxios";
 
 export interface AuthStateProps {
@@ -95,6 +101,11 @@ const authSlice = createSlice({
                 state.isLogin = true;
                 setAccessTokenInAxiosHeaders(action.payload);
             })
+            .addCase(signInUseCode.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.isLogin = true;
+                setAccessTokenInAxiosHeaders(action.payload);
+            })
             .addCase(signIn.rejected, (state, action) => {
                 state.isAsyncReject = true;
                 state.isLoading = false;
@@ -112,6 +123,9 @@ const authSlice = createSlice({
             })
             .addCase(resetPassword.rejected, (state) => {
                 state.errorMessage = `전에 사용한 적 없는 새로운 비밀번호를 만드세요.`;
+            })
+            .addCase(checkCurrentURL.rejected, (state) => {
+                // 유효하지 않은 url **
             });
     },
 });

--- a/src/app/store/ducks/auth/authSlice.ts
+++ b/src/app/store/ducks/auth/authSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { FormState } from "./authThunk.type";
-import { getUserInfo, signIn } from "./authThunk";
+import { getUserInfo, signIn, resetPassword } from "./authThunk";
 import { setAccessTokenInAxiosHeaders } from "customAxios";
 
 export interface AuthStateProps {
@@ -86,6 +86,11 @@ const authSlice = createSlice({
                 state.isAsyncReject = false;
             })
             .addCase(signIn.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.isLogin = true;
+                setAccessTokenInAxiosHeaders(action.payload);
+            })
+            .addCase(resetPassword.fulfilled, (state, action) => {
                 state.isLoading = false;
                 state.isLogin = true;
                 setAccessTokenInAxiosHeaders(action.payload);

--- a/src/app/store/ducks/auth/authSlice.ts
+++ b/src/app/store/ducks/auth/authSlice.ts
@@ -109,6 +109,9 @@ const authSlice = createSlice({
             .addCase(getUserInfo.pending, (state) => {})
             .addCase(getUserInfo.fulfilled, (state, action) => {
                 state.userInfo = action.payload;
+            })
+            .addCase(resetPassword.rejected, (state) => {
+                state.errorMessage = `전에 사용한 적 없는 새로운 비밀번호를 만드세요.`;
             });
     },
 });

--- a/src/app/store/ducks/auth/authThunk.ts
+++ b/src/app/store/ducks/auth/authThunk.ts
@@ -74,16 +74,8 @@ export const checkCurrentURL = createAsyncThunk<
             config,
         );
         console.log(data);
-
-        if (!data.data) {
-            // url 변경 - 유효하지 않은 페이지로 이동
-            // code가 30글자가 아닐 경우 -> 400번 에러
-            // 30글자인데도 올바르지 않을 때도 200번대임
-        } else if (data.status !== 200) {
-            // url 에러 or 프론트에서 파싱 잘못했을 때
-        }
     } catch (error) {
-        // error handling
+        throw ThunkOptions.rejectWithValue(error);
     }
 });
 
@@ -98,7 +90,22 @@ export const resetPassword = createAsyncThunk<
             newPassword: payload.newPassword,
         });
         return data.data;
+    } catch (error) {
+        throw ThunkOptions.rejectWithValue(error);
+    }
+});
+
+export const signInUseCode = createAsyncThunk<
+    AuthType.Token,
+    { code: string; username: string }
+>("auth/signInUseCode", async (payload) => {
+    try {
+        const { data } = await customAxios.post(`/accounts/login/recovery`, {
+            code: payload.code,
+            username: payload.username,
+        });
+        return data.data;
     } catch {
-        // 현재 비밀번호와 동일할 경우
+        // 에러나는 경우? username, code가 잘못됐을 때?
     }
 });

--- a/src/app/store/ducks/auth/authThunk.ts
+++ b/src/app/store/ducks/auth/authThunk.ts
@@ -58,13 +58,47 @@ export const getUserInfo = createAsyncThunk<AuthType.UserInfo>(
     },
 );
 
-// export const resetPassword = createAsyncThunk<>(
-//     "auth/passwordReset",
-//     async (payload, ThunkOptions) => {
-//         try {
-//             // call api
-//         } catch (error) {
-//             // error handling
-//         }
-//     },
-// );
+export const checkCurrentURL = createAsyncThunk<
+    void,
+    { code: string; username: string }
+>("auth/checkResetPassword", async (payload, ThunkOptions) => {
+    try {
+        const config = {
+            params: {
+                code: payload.code,
+                username: payload.username,
+            },
+        };
+        const { data } = await customAxios.get(
+            `/accounts/password/reset`,
+            config,
+        );
+        console.log(data);
+
+        if (!data.data) {
+            // url 변경 - 유효하지 않은 페이지로 이동
+            // code가 30글자가 아닐 경우 -> 400번 에러
+            // 30글자인데도 올바르지 않을 때도 200번대임
+        } else if (data.status !== 200) {
+            // url 에러 or 프론트에서 파싱 잘못했을 때
+        }
+    } catch (error) {
+        // error handling
+    }
+});
+
+export const resetPassword = createAsyncThunk<
+    AuthType.Token,
+    { code: string; username: string; newPassword: string }
+>("auth/resetPassword", async (payload, ThunkOptions) => {
+    try {
+        const { data } = await customAxios.put(`/accounts/password/reset`, {
+            code: payload.code,
+            username: payload.username,
+            newPassword: payload.newPassword,
+        });
+        return data.data;
+    } catch {
+        // 현재 비밀번호와 동일할 경우
+    }
+});

--- a/src/components/Auth/ResetPassword/ResetPasswordForm.tsx
+++ b/src/components/Auth/ResetPassword/ResetPasswordForm.tsx
@@ -73,7 +73,9 @@ const Container = styled.section`
 
 export default function ResetPasswordForm() {
     const { search } = useLocation();
-    const { username, code } = queryString.parse(search);
+    const { username, code } = queryString.parse(
+        search,
+    ) as AuthType.resetPasswordQuery;
     const dispatch = useAppDispatch();
     const { errorMessage } = useAppSelector((state) => state.auth);
 
@@ -90,29 +92,20 @@ export default function ResetPasswordForm() {
     );
 
     useEffect(() => {
-        if (typeof code === "string" && typeof username === "string") {
-            // 타입 체크하는 함수를 만들어야하나?
-            // false면 어떻게 처리할건데?
-            dispatch(checkCurrentURL({ code, username }));
-        }
-        // const stringCode = code as string;
-        // const stringUsername = username as string;
-        // queryString으로 parse할 때, string | (string | null)[] | null일 수도 있음 -> as로 타입 추론하는 코드가 최선인가?
+        dispatch(checkCurrentURL({ code, username }));
     }, []);
 
     const resetPasswordClickHandler = (
         event: MouseEvent<HTMLButtonElement>,
     ) => {
         event.preventDefault();
-        if (typeof code === "string" && typeof username === "string") {
-            dispatch(
-                resetPassword({
-                    code,
-                    username,
-                    newPassword: newPasswordInputProps.value,
-                }),
-            );
-        }
+        dispatch(
+            resetPassword({
+                code,
+                username,
+                newPassword: newPasswordInputProps.value,
+            }),
+        );
     };
 
     return (

--- a/src/components/Auth/ResetPassword/ResetPasswordForm.tsx
+++ b/src/components/Auth/ResetPassword/ResetPasswordForm.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import SubmitButton from "../SubmitButton";
 import useInput from "hooks/useInput";
 import { useEffect, MouseEvent } from "react";
-import { useAppDispatch } from "app/store/Hooks";
+import { useAppDispatch, useAppSelector } from "app/store/Hooks";
 import { checkCurrentURL, resetPassword } from "app/store/ducks/auth/authThunk";
 
 const Container = styled.section`
@@ -59,6 +59,14 @@ const Container = styled.section`
                 margin: 20px 52px 60px 52px;
                 height: 44px;
             }
+
+            .error-message {
+                color: #ed4956;
+                font-size: 14px;
+                line-height: 18px;
+                text-align: center;
+                margin: 10px 40px;
+            }
         }
     }
 `;
@@ -67,6 +75,7 @@ export default function ResetPasswordForm() {
     const { search } = useLocation();
     const { username, code } = queryString.parse(search);
     const dispatch = useAppDispatch();
+    const { errorMessage } = useAppSelector((state) => state.auth);
 
     const [newPasswordInputProps, newPasswordIsValid] = useInput(
         "",
@@ -154,6 +163,11 @@ export default function ResetPasswordForm() {
                             >
                                 비밀번호 재설정
                             </SubmitButton>
+                            {errorMessage && (
+                                <div className="error-message">
+                                    <p>{errorMessage}</p>
+                                </div>
+                            )}
                         </form>
                     </ContentBox>
                 </div>

--- a/src/components/Auth/ResetPassword/ResetPasswordForm.tsx
+++ b/src/components/Auth/ResetPassword/ResetPasswordForm.tsx
@@ -5,6 +5,9 @@ import ContentBox from "components/Common/ContentBox";
 import styled from "styled-components";
 import SubmitButton from "../SubmitButton";
 import useInput from "hooks/useInput";
+import { useEffect, MouseEvent } from "react";
+import { useAppDispatch } from "app/store/Hooks";
+import { checkCurrentURL, resetPassword } from "app/store/ducks/auth/authThunk";
 
 const Container = styled.section`
     background-color: #fff;
@@ -63,6 +66,7 @@ const Container = styled.section`
 export default function ResetPasswordForm() {
     const { search } = useLocation();
     const { username, code } = queryString.parse(search);
+    const dispatch = useAppDispatch();
 
     const [newPasswordInputProps, newPasswordIsValid] = useInput(
         "",
@@ -76,8 +80,31 @@ export default function ResetPasswordForm() {
         (value) => newPasswordInputProps.value === value,
     );
 
-    // submit api 연결
-    // 들어오자마자, code유효한지 체크 -> 그 전까지, loding (using useEffect)
+    useEffect(() => {
+        if (typeof code === "string" && typeof username === "string") {
+            // 타입 체크하는 함수를 만들어야하나?
+            // false면 어떻게 처리할건데?
+            dispatch(checkCurrentURL({ code, username }));
+        }
+        // const stringCode = code as string;
+        // const stringUsername = username as string;
+        // queryString으로 parse할 때, string | (string | null)[] | null일 수도 있음 -> as로 타입 추론하는 코드가 최선인가?
+    }, []);
+
+    const resetPasswordClickHandler = (
+        event: MouseEvent<HTMLButtonElement>,
+    ) => {
+        event.preventDefault();
+        if (typeof code === "string" && typeof username === "string") {
+            dispatch(
+                resetPassword({
+                    code,
+                    username,
+                    newPassword: newPasswordInputProps.value,
+                }),
+            );
+        }
+    };
 
     return (
         <Container>
@@ -123,6 +150,7 @@ export default function ResetPasswordForm() {
                                         reEnterPasswordIsValid
                                     )
                                 }
+                                onClick={resetPasswordClickHandler}
                             >
                                 비밀번호 재설정
                             </SubmitButton>

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -3,7 +3,10 @@ import { useAppDispatch } from "app/store/Hooks";
 import Form from "components/Auth/Form";
 import { Footer } from "components/Common/Footer/Footer";
 import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import styled from "styled-components";
+import queryString from "query-string";
+import { signInUseCode } from "app/store/ducks/auth/authThunk";
 
 const Section = styled.section`
     flex-shrink: 0;
@@ -19,7 +22,16 @@ const Section = styled.section`
 
 export default function AuthPage(props: { router: "signIn" | "signUp" }) {
     const dispatch = useAppDispatch();
+    const { search } = useLocation();
+    const { username, code } = queryString.parse(search);
     useEffect(() => {
+        if (
+            props.router === "signIn" &&
+            typeof username === "string" &&
+            typeof code === "string"
+        ) {
+            dispatch(signInUseCode({ username, code }));
+        }
         dispatch(authAction.changeFormState(props.router));
     }, []);
 

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -23,13 +23,12 @@ const Section = styled.section`
 export default function AuthPage(props: { router: "signIn" | "signUp" }) {
     const dispatch = useAppDispatch();
     const { search } = useLocation();
-    const { username, code } = queryString.parse(search);
+    const { username, code } = queryString.parse(
+        search,
+    ) as AuthType.resetPasswordQuery;
+
     useEffect(() => {
-        if (
-            props.router === "signIn" &&
-            typeof username === "string" &&
-            typeof code === "string"
-        ) {
+        if (props.router === "signIn") {
             dispatch(signInUseCode({ username, code }));
         }
         dispatch(authAction.changeFormState(props.router));


### PR DESCRIPTION
## 개요
- 브랜치: subfeat/login/resetPassword
-  실제 유저가 비밀번호 재설정을 하고자 할 때만 유저의 이메일로 재설정 메일을 통해 재설정 할 수 있음
- 비밀번호 재설정 메일 
    - 로그인: 이메일 인증했기에 유저의 이메일로 로그인 할 수 있음. 
    - 비밀번호 재설정 
    
## 작업사항
-  비밀번호 재설정 클릭 시, url query의 code를 이용해 유효한 페이지인지 체크함
      - 비밀번호 재설정 메일을 통해서만 code를 받을 수 있고, code는 몇 분만 유효함. 
      - 유효한 코드일 경우, 비밀번호 재설정 폼을 통해 비밀번호를 재설정하고, 로그인되어 home이 렌더링 됨. 
- 로그인 클릭 시, url query의 username과 code로 코드를 통한 로그인 api를 호출해 로그인되어 home이 렌더링 됨. 

## 고민 
- method 리턴 타입이 여러개일 때, 어떻게 처리해서 이용하시나요? 
   - 배경: query-string.parse의 리턴타입:`string | (string | null) [] | null`
    - string타입으로 바꿔, 이용하고 싶은데 어떻게 처리하는 게 좋을지 고민이 돼서 남깁니다.
        - `as String`으로 추론하기 ?
        - `typeof value === “string”`인지 체크하고 이용하기? 현재 이 방법으로 구현했는데, 그 값을 이용할 때마다 반복해서 체크해야하다보니..좋지 않은 거 같습니다. 

- 비밀번호 재설정버튼 클릭 시, url query의 code를 이용해 유효한 페이지인지 체크하는데요, 만료된 코드여서 유효하지 않은 페이지를 보여줘야할 때, 리덕스 상태값을 하나 만들어서 라우터를 변경하는 게 어떨까 생각했습니다. 
   - 아래 사진은 실제 인스타그램에서 유효하지 않은 페이지일경우 보여주는 화면입니다. 링크가 잘못됐거나 페이지가 삭제됐을 때도 이 페이지를 이용하는 거 같은데, `auth`외에서 이 페이지를 이용할 경우가 없을까요? 
   - 다른 곳에서도 이용할 수도 있을 거 같아서, 만들려는 상태값을 auth에서 관리해도 될까라는 생각이 들었습니다. 
<img width="1118" alt="스크린샷 2022-05-15 오후 11 31 32" src="https://user-images.githubusercontent.com/70274947/168478164-905330cb-bbad-43da-bc96-9b322d5539bd.png">