### PR TITLE
fix: 상단메뉴 멤버 프로필 조회 api 엔드포인트 수정 적용

### DIFF
--- a/src/app/store/ducks/auth/authThunk.ts
+++ b/src/app/store/ducks/auth/authThunk.ts
@@ -48,7 +48,9 @@ export const getUserInfo = createAsyncThunk<AuthType.UserInfo>(
     "auth/userInfo",
     async (payload, ThunkOptions) => {
         try {
-            const response = await authorizedCustomAxios.get("/menu/profile");
+            const response = await authorizedCustomAxios.get(
+                "/accounts/profile",
+            );
             return response.data.data;
         } catch (error) {
             // error === FAIL_TO_REISSUE_MESSAGE &&


### PR DESCRIPTION

## 작업사항

https://github.com/Instagram-Clone-Coding/React_instagram_clone/issues/59
상단메뉴 멤버 프로필 조회 api 엔드포인트 수정 

