### PR TITLE
Content 단계에 img slider 관련 구현

### DIFF
--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -286,9 +286,8 @@ declare module UploadType {
 
     interface ContentType {
         newUrl: string;
-        // 예정
+        alternativeText: string;
     }
-
     interface FileProps
         extends FileDragAndDropProps,
             FileCutProps,

--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -309,6 +309,8 @@ declare module UploadType {
         grabbedGalleryImgIndex: number | null;
         grabbedGalleryImgNewIndex: number | null;
         textareaValue: string;
+        isLikesAndViewsHidden: boolean;
+        isCommentBlocked: boolean;
     }
 }
 

--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -284,9 +284,15 @@ declare module UploadType {
         // backgroundBlur
     }
 
+    interface HashtagType {
+        tagX: number;
+        tagY: number;
+        username: string;
+    }
     interface ContentType {
         newUrl: string;
         alternativeText: string;
+        hashtags: HashtagType[];
     }
     interface FileProps
         extends FileDragAndDropProps,

--- a/src/app/store/ducks/common/commonSlice.ts
+++ b/src/app/store/ducks/common/commonSlice.ts
@@ -58,6 +58,7 @@ const commontSlice = createSlice({
     },
 });
 
-export const { changeSearchUser, resetRecordedUsers } = commontSlice.actions;
+export const { changeSearchUser, resetRecordedUsers, resetSearch } =
+    commontSlice.actions;
 
 export const commonReducer = commontSlice.reducer;

--- a/src/app/store/ducks/upload/uploadSlice.ts
+++ b/src/app/store/ducks/upload/uploadSlice.ts
@@ -319,6 +319,11 @@ const uploadSlice = createSlice({
                     action.payload;
             }
         },
+        deleteHashtag: (state, action: PayloadAction<number>) => {
+            state.files[state.currentIndex].hashtags = state.files[
+                state.currentIndex
+            ].hashtags.filter((hashtag, index) => index !== action.payload);
+        },
     },
 });
 

--- a/src/app/store/ducks/upload/uploadSlice.ts
+++ b/src/app/store/ducks/upload/uploadSlice.ts
@@ -309,7 +309,15 @@ const uploadSlice = createSlice({
             state.isCommentBlocked = !state.isCommentBlocked;
         },
         addHashtags: (state, action: PayloadAction<UploadType.HashtagType>) => {
-            state.files[state.currentIndex].hashtags.push(action.payload);
+            const index = state.files[state.currentIndex].hashtags.findIndex(
+                (hashtag) => hashtag.username === action.payload.username,
+            );
+            if (index === -1) {
+                state.files[state.currentIndex].hashtags.push(action.payload);
+            } else {
+                state.files[state.currentIndex].hashtags[index] =
+                    action.payload;
+            }
         },
     },
 });

--- a/src/app/store/ducks/upload/uploadSlice.ts
+++ b/src/app/store/ducks/upload/uploadSlice.ts
@@ -10,6 +10,8 @@ const initialState: UploadType.UploadStateProps = {
     grabbedGalleryImgIndex: null,
     grabbedGalleryImgNewIndex: null,
     textareaValue: "",
+    isLikesAndViewsHidden: false,
+    isCommentBlocked: false,
 };
 
 const uploadSlice = createSlice({
@@ -298,6 +300,12 @@ const uploadSlice = createSlice({
         ) => {
             state.files[action.payload.index].alternativeText =
                 action.payload.value;
+        },
+        toggleIsLikesAndViewsHidden: (state) => {
+            state.isLikesAndViewsHidden = !state.isLikesAndViewsHidden;
+        },
+        toggleIsCommentBlocked: (state) => {
+            state.isCommentBlocked = !state.isCommentBlocked;
         },
     },
 });

--- a/src/app/store/ducks/upload/uploadSlice.ts
+++ b/src/app/store/ducks/upload/uploadSlice.ts
@@ -72,6 +72,7 @@ const uploadSlice = createSlice({
                 saturate: 0,
                 blur: 0,
                 newUrl: "",
+                alternativeText: "",
             });
         },
         startGrabbing: (state) => {
@@ -290,6 +291,13 @@ const uploadSlice = createSlice({
         },
         addEmojiOnTextarea: (state, action: PayloadAction<string>) => {
             state.textareaValue += action.payload;
+        },
+        setAlternativeValue: (
+            state,
+            action: PayloadAction<{ value: string; index: number }>,
+        ) => {
+            state.files[action.payload.index].alternativeText =
+                action.payload.value;
         },
     },
 });

--- a/src/app/store/ducks/upload/uploadSlice.ts
+++ b/src/app/store/ducks/upload/uploadSlice.ts
@@ -75,6 +75,7 @@ const uploadSlice = createSlice({
                 blur: 0,
                 newUrl: "",
                 alternativeText: "",
+                hashtags: [],
             });
         },
         startGrabbing: (state) => {
@@ -306,6 +307,9 @@ const uploadSlice = createSlice({
         },
         toggleIsCommentBlocked: (state) => {
             state.isCommentBlocked = !state.isCommentBlocked;
+        },
+        addHashtags: (state, action: PayloadAction<UploadType.HashtagType>) => {
+            state.files[state.currentIndex].hashtags.push(action.payload);
         },
     },
 });

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -14,6 +14,7 @@ import { ReactComponent as LocationIcon } from "assets/Svgs/location.svg";
 import Picker, { IEmojiData } from "emoji-picker-react";
 import UploadImgArrowAndDots from "components/Common/Header/UploadImgArrowAndDots";
 import sprite from "assets/Images/sprite.png";
+import useInput from "hooks/useInput";
 
 const StyledContent = styled.div`
     display: flex;
@@ -34,7 +35,7 @@ const StyledContent = styled.div`
                 height: 14px;
                 width: 14px;
                 background-color: white;
-                transform: rotate(45deg);
+                transform: translateX(-5px) rotate(45deg);
             }
             & > .modal {
                 box-shadow: rgba(0, 0, 0, 0.098) 0px 0px 5px 1px;
@@ -42,7 +43,7 @@ const StyledContent = styled.div`
                 height: 226px;
                 background-color: white;
                 position: relative;
-                left: -18px;
+                left: -23px;
                 top: -7px;
                 border-radius: 6px;
                 & > * {
@@ -297,6 +298,7 @@ const Content = ({ currentWidth }: ContentProps) => {
     const { userInfo } = useAppSelector((state) => state.auth);
     const [isSearchBarOn, setIsSearchBarOn] = useState(false);
     const [searchBarPosition, setSearchBarPosition] = useState({ x: 0, y: 0 }); // %
+    const [searchInputProps, , , resetSearchInput] = useInput("");
     const [isEmojiModalOn, setIsEmojiModalOn] = useState(false);
     const [isAccessOptionOn, setIsAccessOptionOn] = useState(false);
     const [isAdvancedOptionOn, setIsAdvancedOptionOn] = useState(false);
@@ -437,8 +439,15 @@ const Content = ({ currentWidth }: ContentProps) => {
                             <div className="modal">
                                 <div className="modal__header">
                                     <h4>태그:</h4>
-                                    <input type="text" placeholder="검색" />
-                                    <span></span>
+                                    <input
+                                        type="text"
+                                        placeholder="검색"
+                                        {...searchInputProps}
+                                        autoFocus={true}
+                                    />
+                                    {searchInputProps.value && (
+                                        <span onClick={resetSearchInput}></span>
+                                    )}
                                 </div>
                                 <div className="modal__searched"></div>
                             </div>
@@ -491,7 +500,7 @@ const Content = ({ currentWidth }: ContentProps) => {
                                 // disabled={true}
                                 placeholder="위치 추가(개발 준비중)"
                             />
-                            <span>
+                            <span onClick={resetSearchInput}>
                                 <LocationIcon />
                             </span>
                         </div>

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -13,6 +13,7 @@ import { ReactComponent as DownV } from "assets/Svgs/downV.svg";
 import { ReactComponent as LocationIcon } from "assets/Svgs/location.svg";
 import Picker, { IEmojiData } from "emoji-picker-react";
 import UploadImgArrowAndDots from "components/Common/Header/UploadImgArrowAndDots";
+import sprite from "assets/Images/sprite.png";
 
 const StyledContent = styled.div`
     display: flex;
@@ -22,6 +23,62 @@ const StyledContent = styled.div`
         justify-content: center;
         align-items: center;
         position: relative;
+        & > img {
+            cursor: crosshair;
+        }
+        & > .searchBar {
+            position: absolute;
+            z-index: 1000;
+            & > .pointer {
+                box-shadow: rgba(0, 0, 0, 0.098) 0px 0px 5px 1px;
+                height: 14px;
+                width: 14px;
+                background-color: white;
+                transform: rotate(45deg);
+            }
+            & > .modal {
+                box-shadow: rgba(0, 0, 0, 0.098) 0px 0px 5px 1px;
+                width: 338px;
+                height: 226px;
+                background-color: white;
+                position: relative;
+                left: -18px;
+                top: -7px;
+                border-radius: 6px;
+                & > * {
+                    width: 100%;
+                }
+                & > .modal__header {
+                    display: flex;
+                    align-items: center;
+                    position: relative;
+                    padding: 10px 8px;
+                    border-bottom: 1px solid
+                        ${(props) => props.theme.color.bd_gray};
+                    & > h4 {
+                        padding: 4px 12px;
+                        font-size: 16px;
+                        font-weight: ${(props) => props.theme.font.bold};
+                    }
+                    & > input {
+                        background-color: transparent;
+                        border: none;
+                        flex: 1;
+                        padding: 4px 12px 4px 0px;
+                        height: 28px;
+                    }
+                    & > span {
+                        position: absolute;
+                        right: 12px;
+                        background-image: url(${sprite});
+                        background-repeat: no-repeat;
+                        background-position: -500px -196px;
+                        height: 20px;
+                        width: 20px;
+                    }
+                }
+            }
+        }
     }
     & > .upload__contents {
         width: 340px;
@@ -238,6 +295,8 @@ const Content = ({ currentWidth }: ContentProps) => {
         isCommentBlocked,
     } = useAppSelector((state) => state.upload);
     const { userInfo } = useAppSelector((state) => state.auth);
+    const [isSearchBarOn, setIsSearchBarOn] = useState(false);
+    const [searchBarPosition, setSearchBarPosition] = useState({ x: 0, y: 0 }); // %
     const [isEmojiModalOn, setIsEmojiModalOn] = useState(false);
     const [isAccessOptionOn, setIsAccessOptionOn] = useState(false);
     const [isAdvancedOptionOn, setIsAdvancedOptionOn] = useState(false);
@@ -313,6 +372,27 @@ const Content = ({ currentWidth }: ContentProps) => {
         });
     }, [dispatch, ratioMode]);
 
+    const changeSearchBarPosition = (
+        event: React.MouseEvent<HTMLImageElement>,
+    ) => {
+        const { clientX, clientY, currentTarget } = event;
+        const {
+            x: left,
+            y: top,
+            width,
+            height,
+        } = currentTarget.getBoundingClientRect();
+        const x = ((clientX - left) / width) * 100;
+        const y = ((clientY - top) / height) * 100;
+        setSearchBarPosition({ x, y });
+    };
+
+    const ImgClickHandler = (event: React.MouseEvent<HTMLImageElement>) => {
+        if (isSearchBarOn) return setIsSearchBarOn(false);
+        changeSearchBarPosition(event);
+        setIsSearchBarOn(true);
+    };
+
     return (
         <>
             <UploadHeader
@@ -342,7 +422,27 @@ const Content = ({ currentWidth }: ContentProps) => {
                                 ratioMode,
                                 currentWidth,
                             )}
+                            onClick={ImgClickHandler}
                         />
+                    )}
+                    {isSearchBarOn && (
+                        <div
+                            className="searchBar"
+                            style={{
+                                left: `${searchBarPosition.x}%`,
+                                top: `${searchBarPosition.y}%`,
+                            }}
+                        >
+                            <div className="pointer"></div>
+                            <div className="modal">
+                                <div className="modal__header">
+                                    <h4>태그:</h4>
+                                    <input type="text" placeholder="검색" />
+                                    <span></span>
+                                </div>
+                                <div className="modal__searched"></div>
+                            </div>
+                        </div>
                     )}
                     {files.length > 1 && (
                         <UploadImgArrowAndDots

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -31,9 +31,42 @@ const StyledContent = styled.div`
             position: relative;
             & > .hashtag {
                 position: absolute;
-                background: red;
-                width: 200px;
-                height: 200px;
+                & * {
+                    color: white;
+                    font-size: 14px;
+                }
+                & > .hashtag__relative {
+                    position: relative;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    & > .pointer {
+                        position: absolute;
+                        width: 15px;
+                        height: 15px;
+                        transform: rotate(45deg);
+                        background-color: black;
+                    }
+                    & > .content {
+                        background: black;
+                        display: flex;
+                        justify-content: space-between;
+                        align-items: center;
+                        padding: 8px 12px;
+                        position: absolute;
+                        top: 7px;
+                        border-radius: 8px;
+                        & > .username {
+                            font-weight: ${(props) => props.theme.font.bold};
+                            margin: 0 4px;
+                        }
+                        & > .closeButton {
+                            width: 16px;
+                            height: 16px;
+                            font-weight: normal;
+                        }
+                    }
+                }
             }
             & > img {
                 cursor: crosshair;
@@ -405,7 +438,6 @@ const Content = ({ currentWidth }: ContentProps) => {
             width,
             height,
         } = currentTarget.getBoundingClientRect();
-        console.log(left, top, width, height);
         const x = ((clientX - left) / width) * 100;
         const y = ((clientY - top) / height) * 100;
         setSearchBarPosition({ x, y });
@@ -424,11 +456,10 @@ const Content = ({ currentWidth }: ContentProps) => {
 
     const searchListItemClickHandler = (username: string) => {
         const { x: tagX, y: tagY } = searchBarPosition;
-        console.log(username);
         dispatch(uploadActions.addHashtags({ tagX, tagY, username }));
         setIsSearchBarOn(false);
     };
-    console.log(files[currentIndex].hashtags);
+
     return (
         <>
             <UploadHeader
@@ -476,17 +507,25 @@ const Content = ({ currentWidth }: ContentProps) => {
                                     }}
                                     className="hashtag"
                                 >
-                                    <div>{username}</div>
-                                    <div
-                                        onClick={() =>
-                                            dispatch(
-                                                uploadActions.deleteHashtag(
-                                                    index,
-                                                ),
-                                            )
-                                        }
-                                    >
-                                        <Close />
+                                    <div className="hashtag__relative">
+                                        <div className="pointer"></div>
+                                        <div className="content">
+                                            <div className="username">
+                                                {username}
+                                            </div>
+                                            <button
+                                                className="closeButton"
+                                                onClick={() =>
+                                                    dispatch(
+                                                        uploadActions.deleteHashtag(
+                                                            index,
+                                                        ),
+                                                    )
+                                                }
+                                            >
+                                                <Close />
+                                            </button>
+                                        </div>
                                     </div>
                                 </div>
                             ),

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -89,17 +89,22 @@ const StyledContent = styled.div`
         & > .upload__contentOption {
             width: 100%;
             border-top: 1px solid ${(props) => props.theme.color.bd_gray};
-            padding: 14px 16px;
             display: flex;
             align-items: center;
             justify-content: center;
-            height: 44px;
+            flex-direction: column;
+            min-height: 44px;
             cursor: pointer;
             & * {
                 font-size: 16px;
             }
-            & > .header {
+            & > .header,
+            & > .activated {
                 width: 100%;
+                padding: 14px 16px;
+            }
+            & > .header {
+                padding: 14px 16px;
                 display: flex;
                 align-items: center;
                 justify-content: space-between;
@@ -128,6 +133,32 @@ const StyledContent = styled.div`
                 & > span {
                     & > svg {
                         transform: none;
+                    }
+                }
+            }
+            & > .activated {
+                padding-top: 0;
+                & .smallFont {
+                    font-size: 12px;
+                    color: ${(props) => props.theme.font.gray};
+                }
+                & > div {
+                    height: 44px;
+                    margin: 12px 0 16px 0;
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    & > img,
+                    & > input {
+                        height: 44px;
+                    }
+                    & > input {
+                        margin-left: 8px;
+                        width: 255px;
+                        background-color: transparent;
+                        border-radius: 6px;
+                        font-size: 14px;
+                        padding: 4px 12px;
                     }
                 }
             }
@@ -316,6 +347,29 @@ const Content = ({ currentWidth }: ContentProps) => {
                                 <DownV />
                             </span>
                         </div>
+                        {isAccessOptionOn && (
+                            <div className="activated">
+                                <div className="smallFont">
+                                    대체 텍스트는 시각적으로 사진을 보기 어려운
+                                    사람들에게 사진 내용을 설명하는
+                                    텍스트입니다. 대체 텍스트는 회원님의 사진에
+                                    대해 자동으로 생성되며, 직접 입력할 수도
+                                    있습니다.
+                                </div>
+                                {files.map((file) => (
+                                    <div key={file.newUrl}>
+                                        <img
+                                            src={file.newUrl}
+                                            alt={"유효하지 않은 url입니다."}
+                                        ></img>
+                                        <input
+                                            type="text"
+                                            placeholder="대체 텍스트 입력..."
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+                        )}
                     </div>
                     <div
                         className="upload__contentOption advanced"
@@ -331,6 +385,9 @@ const Content = ({ currentWidth }: ContentProps) => {
                                 <DownV />
                             </span>
                         </div>
+                        {isAdvancedOptionOn && (
+                            <div className="activated">hello</div>
+                        )}
                     </div>
                     <hr />
                 </div>

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -479,7 +479,10 @@ const Content = ({ currentWidth }: ContentProps) => {
                                     />
                                     {searchInput && (
                                         <span
-                                            onClick={() => setSearchInput("")}
+                                            onClick={() => {
+                                                dispatch(resetSearch());
+                                                setSearchInput("");
+                                            }}
                                         ></span>
                                     )}
                                 </div>

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -335,11 +335,11 @@ const Content = ({ currentWidth }: ContentProps) => {
                             </span>
                         </div>
                     </div>
-                    <div
-                        className="upload__contentOption accessibility"
-                        onClick={() => setIsAccessOptionOn((prev) => !prev)}
-                    >
-                        <div className="header">
+                    <div className="upload__contentOption accessibility">
+                        <div
+                            className="header"
+                            onClick={() => setIsAccessOptionOn((prev) => !prev)}
+                        >
                             <span className={isAccessOptionOn ? "bold" : ""}>
                                 접근성
                             </span>
@@ -371,11 +371,13 @@ const Content = ({ currentWidth }: ContentProps) => {
                             </div>
                         )}
                     </div>
-                    <div
-                        className="upload__contentOption advanced"
-                        onClick={() => setIsAdvancedOptionOn((prev) => !prev)}
-                    >
-                        <div className="header">
+                    <div className="upload__contentOption advanced">
+                        <div
+                            className="header"
+                            onClick={() =>
+                                setIsAdvancedOptionOn((prev) => !prev)
+                            }
+                        >
                             <span className={isAdvancedOptionOn ? "bold" : ""}>
                                 고급 설정
                             </span>

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -17,6 +17,7 @@ import sprite from "assets/Images/sprite.png";
 import { searchUser } from "app/store/ducks/common/commonThunk";
 import SearchListItemLayout from "components/Home/SearchListItemLayout";
 import { resetSearch } from "app/store/ducks/common/commonSlice";
+import { ReactComponent as Close } from "assets/Svgs/close.svg";
 
 const StyledContent = styled.div`
     display: flex;
@@ -466,7 +467,7 @@ const Content = ({ currentWidth }: ContentProps) => {
                             />
                         )}
                         {currentFile.hashtags.map(
-                            ({ tagX, tagY, username }) => (
+                            ({ tagX, tagY, username }, index) => (
                                 <div
                                     key={username}
                                     style={{
@@ -475,7 +476,18 @@ const Content = ({ currentWidth }: ContentProps) => {
                                     }}
                                     className="hashtag"
                                 >
-                                    {username}
+                                    <div>{username}</div>
+                                    <div
+                                        onClick={() =>
+                                            dispatch(
+                                                uploadActions.deleteHashtag(
+                                                    index,
+                                                ),
+                                            )
+                                        }
+                                    >
+                                        <Close />
+                                    </div>
                                 </div>
                             ),
                         )}

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -26,65 +26,76 @@ const StyledContent = styled.div`
         justify-content: center;
         align-items: center;
         position: relative;
-        & > img {
-            cursor: crosshair;
-        }
-        & > .searchBar {
-            position: absolute;
-            z-index: 1000;
-            & > .pointer {
-                box-shadow: rgba(0, 0, 0, 0.098) 0px 0px 5px 1px;
-                height: 14px;
-                width: 14px;
-                background-color: white;
-                transform: translateX(-5px) rotate(45deg);
+        & > .contentImg__relative {
+            position: relative;
+            & > .hashtag {
+                position: absolute;
+                background: red;
+                width: 200px;
+                height: 200px;
             }
-            & > .modal {
-                box-shadow: rgba(0, 0, 0, 0.098) 0px 0px 5px 1px;
-                width: 338px;
-                height: 226px;
-                background-color: white;
-                position: relative;
-                left: -23px;
-                top: -7px;
-                border-radius: 6px;
-                & > * {
-                    width: 100%;
+            & > img {
+                cursor: crosshair;
+                width: 100%;
+                height: 100%;
+            }
+            & > .searchBar {
+                position: absolute;
+                z-index: 1000;
+                & > .pointer {
+                    box-shadow: rgba(0, 0, 0, 0.098) 0px 0px 5px 1px;
+                    height: 14px;
+                    width: 14px;
+                    background-color: white;
+                    transform: translateX(-5px) rotate(45deg);
                 }
-                & > .modal__header {
-                    display: flex;
-                    align-items: center;
+                & > .modal {
+                    box-shadow: rgba(0, 0, 0, 0.098) 0px 0px 5px 1px;
+                    width: 338px;
+                    height: 226px;
+                    background-color: white;
                     position: relative;
-                    padding: 10px 8px;
-                    height: 46px;
-                    border-bottom: 1px solid
-                        ${(props) => props.theme.color.bd_gray};
-                    & > h4 {
-                        padding: 4px 12px;
-                        font-size: 16px;
-                        font-weight: ${(props) => props.theme.font.bold};
+                    left: -23px;
+                    top: -7px;
+                    border-radius: 6px;
+                    & > * {
+                        width: 100%;
                     }
-                    & > input {
-                        background-color: transparent;
-                        border: none;
-                        flex: 1;
-                        padding: 4px 12px 4px 0px;
-                        height: 28px;
+                    & > .modal__header {
+                        display: flex;
+                        align-items: center;
+                        position: relative;
+                        padding: 10px 8px;
+                        height: 46px;
+                        border-bottom: 1px solid
+                            ${(props) => props.theme.color.bd_gray};
+                        & > h4 {
+                            padding: 4px 12px;
+                            font-size: 16px;
+                            font-weight: ${(props) => props.theme.font.bold};
+                        }
+                        & > input {
+                            background-color: transparent;
+                            border: none;
+                            flex: 1;
+                            padding: 4px 12px 4px 0px;
+                            height: 28px;
+                        }
+                        & > span {
+                            position: absolute;
+                            right: 12px;
+                            background-image: url(${sprite});
+                            background-repeat: no-repeat;
+                            background-position: -500px -196px;
+                            height: 20px;
+                            width: 20px;
+                        }
                     }
-                    & > span {
-                        position: absolute;
-                        right: 12px;
-                        background-image: url(${sprite});
-                        background-repeat: no-repeat;
-                        background-position: -500px -196px;
-                        height: 20px;
-                        width: 20px;
+                    & > .modal__searched {
+                        width: 100%;
+                        height: 180px;
+                        overflow-y: auto;
                     }
-                }
-                & > .modal__searched {
-                    width: 100%;
-                    height: 180px;
-                    overflow-y: auto;
                 }
             }
         }
@@ -393,6 +404,7 @@ const Content = ({ currentWidth }: ContentProps) => {
             width,
             height,
         } = currentTarget.getBoundingClientRect();
+        console.log(left, top, width, height);
         const x = ((clientX - left) / width) * 100;
         const y = ((clientY - top) / height) * 100;
         setSearchBarPosition({ x, y });
@@ -411,9 +423,11 @@ const Content = ({ currentWidth }: ContentProps) => {
 
     const searchListItemClickHandler = (username: string) => {
         const { x: tagX, y: tagY } = searchBarPosition;
+        console.log(username);
         dispatch(uploadActions.addHashtags({ tagX, tagY, username }));
+        setIsSearchBarOn(false);
     };
-
+    console.log(files[currentIndex].hashtags);
     return (
         <>
             <UploadHeader
@@ -431,81 +445,105 @@ const Content = ({ currentWidth }: ContentProps) => {
                         minHeight: currentWidth,
                     }}
                 >
-                    {currentFile.newUrl !== "" && (
-                        <img
-                            src={currentFile.newUrl}
-                            alt={"태그할 수 있는 사진"}
-                            width={getRatioCalculatedBoxWidth(
+                    <div
+                        className="contentImg__relative"
+                        style={{
+                            width: getRatioCalculatedBoxWidth(
                                 ratioMode,
                                 currentWidth,
-                            )}
-                            height={getRatioCalculatedBoxHeight(
+                            ),
+                            height: getRatioCalculatedBoxHeight(
                                 ratioMode,
                                 currentWidth,
-                            )}
-                            onClick={ImgClickHandler}
-                        />
-                    )}
-                    {isSearchBarOn && (
-                        <div
-                            className="searchBar"
-                            style={{
-                                left: `${searchBarPosition.x}%`,
-                                top: `${searchBarPosition.y}%`,
-                            }}
-                        >
-                            <div className="pointer"></div>
-                            <div className="modal">
-                                <div className="modal__header">
-                                    <h4>태그:</h4>
-                                    <input
-                                        type="text"
-                                        placeholder="검색"
-                                        value={searchInput}
-                                        onChange={async (event) => {
-                                            setSearchInput(event.target.value);
-                                            if (event.target.value !== "") {
-                                                await dispatch(
-                                                    searchUser({
-                                                        keyword:
-                                                            event.target.value,
-                                                    }),
-                                                );
-                                            } else {
-                                                dispatch(resetSearch());
-                                            }
-                                        }}
-                                        autoFocus={true}
-                                    />
-                                    {searchInput && (
-                                        <span
-                                            onClick={() => {
-                                                dispatch(resetSearch());
-                                                setSearchInput("");
-                                            }}
-                                        ></span>
-                                    )}
+                            ),
+                        }}
+                    >
+                        {currentFile.newUrl !== "" && (
+                            <img
+                                src={currentFile.newUrl}
+                                alt={"태그할 수 있는 사진"}
+                                onClick={ImgClickHandler}
+                            />
+                        )}
+                        {currentFile.hashtags.map(
+                            ({ tagX, tagY, username }) => (
+                                <div
+                                    key={username}
+                                    style={{
+                                        left: tagX + "%",
+                                        top: tagY + "%",
+                                    }}
+                                    className="hashtag"
+                                >
+                                    {username}
                                 </div>
-                                <div className="modal__searched">
-                                    {searchedUsers.length > 0 &&
-                                        searchedUsers.map((user) => (
-                                            <div
-                                                onClick={() =>
-                                                    searchListItemClickHandler(
-                                                        user.member.username,
-                                                    )
+                            ),
+                        )}
+                        {isSearchBarOn && (
+                            <div
+                                className="searchBar"
+                                style={{
+                                    left: `${searchBarPosition.x}%`,
+                                    top: `${searchBarPosition.y}%`,
+                                }}
+                            >
+                                <div className="pointer"></div>
+                                <div className="modal">
+                                    <div className="modal__header">
+                                        <h4>태그:</h4>
+                                        <input
+                                            type="text"
+                                            placeholder="검색"
+                                            value={searchInput}
+                                            onChange={async (event) => {
+                                                setSearchInput(
+                                                    event.target.value,
+                                                );
+                                                if (event.target.value !== "") {
+                                                    await dispatch(
+                                                        searchUser({
+                                                            keyword:
+                                                                event.target
+                                                                    .value,
+                                                        }),
+                                                    );
+                                                } else {
+                                                    dispatch(resetSearch());
                                                 }
-                                                key={user.member.id}
-                                            >
-                                                <SearchListItemLayout
-                                                    member={user.member}
-                                                />
-                                            </div>
-                                        ))}
+                                            }}
+                                            autoFocus={true}
+                                        />
+                                        {searchInput && (
+                                            <span
+                                                onClick={() => {
+                                                    dispatch(resetSearch());
+                                                    setSearchInput("");
+                                                }}
+                                            ></span>
+                                        )}
+                                    </div>
+                                    <div className="modal__searched">
+                                        {searchedUsers.length > 0 &&
+                                            searchedUsers.map((user) => (
+                                                <div
+                                                    onClick={() =>
+                                                        searchListItemClickHandler(
+                                                            user.member
+                                                                .username,
+                                                        )
+                                                    }
+                                                    key={user.member.id}
+                                                >
+                                                    <SearchListItemLayout
+                                                        member={user.member}
+                                                    />
+                                                </div>
+                                            ))}
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    )}
+                        )}
+                    </div>
                     {files.length > 1 && (
                         <UploadImgArrowAndDots
                             currentIndex={currentIndex}

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -138,19 +138,26 @@ const StyledContent = styled.div`
             }
             & > .activated {
                 padding-top: 0;
-                & .smallFont {
+                & > .smallFont {
                     font-size: 12px;
                     color: ${(props) => props.theme.font.gray};
                 }
+
                 & > div {
                     height: 44px;
                     margin: 12px 0 16px 0;
                     display: flex;
                     align-items: center;
-                    justify-content: space-between;
-                    & > img,
+                    & > .imageWrapper,
                     & > input {
                         height: 44px;
+                    }
+                    & > .imageWrapper {
+                        width: 44px;
+                        height: 44px;
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
                     }
                     & > input {
                         margin-left: 8px;
@@ -358,10 +365,17 @@ const Content = ({ currentWidth }: ContentProps) => {
                                 </div>
                                 {files.map((file) => (
                                     <div key={file.newUrl}>
-                                        <img
-                                            src={file.newUrl}
-                                            alt={"유효하지 않은 url입니다."}
-                                        ></img>
+                                        <div className="imageWrapper">
+                                            <img
+                                                src={file.newUrl}
+                                                alt={"유효하지 않은 url입니다."}
+                                                width={
+                                                    ratioMode !== "thin"
+                                                        ? 44
+                                                        : 44 * 0.8
+                                                }
+                                            ></img>
+                                        </div>
                                         <input
                                             type="text"
                                             placeholder="대체 텍스트 입력..."

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -143,7 +143,7 @@ const StyledContent = styled.div`
                     color: ${(props) => props.theme.font.gray};
                 }
 
-                & > div {
+                &.accessOption > div {
                     height: 44px;
                     margin: 12px 0 16px 0;
                     display: flex;
@@ -174,6 +174,42 @@ const StyledContent = styled.div`
                         padding: 4px 12px;
                     }
                 }
+                &.advanced > div {
+                    &.toggleArea {
+                        height: 28px;
+                        display: flex;
+                        justify-content: space-between;
+                        align-items: center;
+                        & > .toggle {
+                            width: 44px;
+                            height: 100%;
+                            background-color: ${(props) =>
+                                props.theme.font.gray};
+                            border-radius: 14px;
+                            display: flex;
+                            align-items: center;
+                            padding: 0 3px;
+                            transition: background-color 0.5s;
+                            & > div {
+                                transition: transform 0.5s;
+                                width: 22px;
+                                height: 22px;
+                                background-color: white;
+                                border-radius: 50%;
+                            }
+                            &.on {
+                                background-color: ${(props) =>
+                                    props.theme.color.blue};
+                                & > div {
+                                    transform: translateX(15px);
+                                }
+                            }
+                        }
+                    }
+                    &.smallFont {
+                        padding: 12px 0;
+                    }
+                }
             }
         }
         & > hr {
@@ -189,12 +225,17 @@ const StyledContent = styled.div`
 interface ContentProps {
     currentWidth: number;
 }
-
 const Content = ({ currentWidth }: ContentProps) => {
+    console.log("rerendered");
     const dispatch = useAppDispatch();
-    const { files, currentIndex, ratioMode, textareaValue } = useAppSelector(
-        (state) => state.upload,
-    );
+    const {
+        files,
+        currentIndex,
+        ratioMode,
+        textareaValue,
+        isLikesAndViewsHidden,
+        isCommentBlocked,
+    } = useAppSelector((state) => state.upload);
     const { userInfo } = useAppSelector((state) => state.auth);
     const [isEmojiModalOn, setIsEmojiModalOn] = useState(false);
     const [isAccessOptionOn, setIsAccessOptionOn] = useState(false);
@@ -361,7 +402,7 @@ const Content = ({ currentWidth }: ContentProps) => {
                             </span>
                         </div>
                         {isAccessOptionOn && (
-                            <div className="activated">
+                            <div className="activated accessOption">
                                 <div className="smallFont">
                                     {`대체 텍스트는 시각적으로 사진을 보기 어려운 사람들에게 사진
                                     내용을 설명하는 텍스트입니다. 대체 텍스트는 회원님의 사진에
@@ -418,12 +459,23 @@ const Content = ({ currentWidth }: ContentProps) => {
                             </span>
                         </div>
                         {isAdvancedOptionOn && (
-                            <div className="activated">
-                                <div>
+                            <div className="activated advanced">
+                                <div className="toggleArea">
                                     <div>
                                         이 게시물의 좋아요 수 및 조회수 숨기기
                                     </div>
-                                    <div></div>
+                                    <div
+                                        onClick={() =>
+                                            dispatch(
+                                                uploadActions.toggleIsLikesAndViewsHidden(),
+                                            )
+                                        }
+                                        className={`toggle ${
+                                            isLikesAndViewsHidden && "on"
+                                        }`}
+                                    >
+                                        <div></div>
+                                    </div>
                                 </div>
                                 <div className="smallFont">
                                     이 게시물의 총 좋아요 및 조회수는 회원님만
@@ -432,9 +484,20 @@ const Content = ({ currentWidth }: ContentProps) => {
                                     다른 사람의 게시물에서 좋아요 수를 숨기려면
                                     계정 설정으로 이동하세요.
                                 </div>
-                                <div>
+                                <div className="toggleArea">
                                     <div>댓글 기능 해제</div>
-                                    <div></div>
+                                    <div
+                                        onClick={() =>
+                                            dispatch(
+                                                uploadActions.toggleIsCommentBlocked(),
+                                            )
+                                        }
+                                        className={`toggle ${
+                                            isCommentBlocked && "on"
+                                        }`}
+                                    >
+                                        <div></div>
+                                    </div>
                                 </div>
                                 <div className="smallFont">
                                     나중에 게시물 상단의 메뉴(···)에서 이 설정을

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -151,6 +151,9 @@ const StyledContent = styled.div`
                     & > .imageWrapper,
                     & > input {
                         height: 44px;
+                        &:focus {
+                            border: 1px solid #a8a8a8;
+                        }
                     }
                     & > .imageWrapper {
                         width: 44px;

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -92,29 +92,35 @@ const StyledContent = styled.div`
             padding: 14px 16px;
             display: flex;
             align-items: center;
-            justify-content: space-between;
+            justify-content: center;
             height: 44px;
             cursor: pointer;
-            & > * {
+            & * {
                 font-size: 16px;
             }
-            & > span {
+            & > .header {
+                width: 100%;
                 display: flex;
-                justify-content: center;
                 align-items: center;
-                & > svg {
-                    transform: rotate(180deg);
-                    width: 16px;
-                    height: 16px;
-                }
-                &.bold {
-                    font-weight: ${(props) => props.theme.font.bold};
-                }
-                &.reverse {
-                    transform: rotate(180deg);
+                justify-content: space-between;
+                & > span {
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    & > svg {
+                        transform: rotate(180deg);
+                        width: 16px;
+                        height: 16px;
+                    }
+                    &.bold {
+                        font-weight: ${(props) => props.theme.font.bold};
+                    }
+                    &.reverse {
+                        transform: rotate(180deg);
+                    }
                 }
             }
-            &.location {
+            &.location > .header {
                 & > input {
                     border: none;
                     background-color: transparent;
@@ -288,35 +294,43 @@ const Content = ({ currentWidth }: ContentProps) => {
                         </div>
                     </div>
                     <div className="upload__contentOption location">
-                        <input
-                            // disabled={true}
-                            placeholder="위치 추가(개발 준비중)"
-                        />
-                        <span>
-                            <LocationIcon />
-                        </span>
+                        <div className="header">
+                            <input
+                                // disabled={true}
+                                placeholder="위치 추가(개발 준비중)"
+                            />
+                            <span>
+                                <LocationIcon />
+                            </span>
+                        </div>
                     </div>
                     <div
                         className="upload__contentOption accessibility"
                         onClick={() => setIsAccessOptionOn((prev) => !prev)}
                     >
-                        <span className={isAccessOptionOn ? "bold" : ""}>
-                            접근성
-                        </span>
-                        <span className={isAccessOptionOn ? "reverse" : ""}>
-                            <DownV />
-                        </span>
+                        <div className="header">
+                            <span className={isAccessOptionOn ? "bold" : ""}>
+                                접근성
+                            </span>
+                            <span className={isAccessOptionOn ? "reverse" : ""}>
+                                <DownV />
+                            </span>
+                        </div>
                     </div>
                     <div
                         className="upload__contentOption advanced"
                         onClick={() => setIsAdvancedOptionOn((prev) => !prev)}
                     >
-                        <span className={isAdvancedOptionOn ? "bold" : ""}>
-                            고급 설정
-                        </span>
-                        <span className={isAdvancedOptionOn ? "reverse" : ""}>
-                            <DownV />
-                        </span>
+                        <div className="header">
+                            <span className={isAdvancedOptionOn ? "bold" : ""}>
+                                고급 설정
+                            </span>
+                            <span
+                                className={isAdvancedOptionOn ? "reverse" : ""}
+                            >
+                                <DownV />
+                            </span>
+                        </div>
                     </div>
                     <hr />
                 </div>

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -308,7 +308,6 @@ const Content = ({ currentWidth }: ContentProps) => {
     const [isSearchBarOn, setIsSearchBarOn] = useState(false);
     const [searchBarPosition, setSearchBarPosition] = useState({ x: 0, y: 0 }); // %
     const [searchInput, setSearchInput] = useState("");
-    // const [isSearchedUserFocused];
     const [isEmojiModalOn, setIsEmojiModalOn] = useState(false);
     const [isAccessOptionOn, setIsAccessOptionOn] = useState(false);
     const [isAdvancedOptionOn, setIsAdvancedOptionOn] = useState(false);
@@ -410,6 +409,11 @@ const Content = ({ currentWidth }: ContentProps) => {
         }
     };
 
+    const searchListItemClickHandler = (username: string) => {
+        const { x: tagX, y: tagY } = searchBarPosition;
+        dispatch(uploadActions.addHashtags({ tagX, tagY, username }));
+    };
+
     return (
         <>
             <UploadHeader
@@ -482,10 +486,18 @@ const Content = ({ currentWidth }: ContentProps) => {
                                 <div className="modal__searched">
                                     {searchedUsers.length > 0 &&
                                         searchedUsers.map((user) => (
-                                            <SearchListItemLayout
-                                                member={user.member}
+                                            <div
+                                                onClick={() =>
+                                                    searchListItemClickHandler(
+                                                        user.member.username,
+                                                    )
+                                                }
                                                 key={user.member.id}
-                                            />
+                                            >
+                                                <SearchListItemLayout
+                                                    member={user.member}
+                                                />
+                                            </div>
                                         ))}
                                 </div>
                             </div>

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -154,6 +154,9 @@ const StyledContent = styled.div`
                         &:focus {
                             border: 1px solid #a8a8a8;
                         }
+                        &::placeholder {
+                            color: #c7c7c7;
+                        }
                     }
                     & > .imageWrapper {
                         width: 44px;
@@ -360,13 +363,11 @@ const Content = ({ currentWidth }: ContentProps) => {
                         {isAccessOptionOn && (
                             <div className="activated">
                                 <div className="smallFont">
-                                    대체 텍스트는 시각적으로 사진을 보기 어려운
-                                    사람들에게 사진 내용을 설명하는
-                                    텍스트입니다. 대체 텍스트는 회원님의 사진에
-                                    대해 자동으로 생성되며, 직접 입력할 수도
-                                    있습니다.
+                                    {`대체 텍스트는 시각적으로 사진을 보기 어려운 사람들에게 사진
+                                    내용을 설명하는 텍스트입니다. 대체 텍스트는 회원님의 사진에
+                                    대해 자동으로 생성되며, 직접 입력할 수도 있습니다.`}
                                 </div>
-                                {files.map((file) => (
+                                {files.map((file, index) => (
                                     <div key={file.newUrl}>
                                         <div className="imageWrapper">
                                             <img
@@ -382,6 +383,18 @@ const Content = ({ currentWidth }: ContentProps) => {
                                         <input
                                             type="text"
                                             placeholder="대체 텍스트 입력..."
+                                            value={file.alternativeText}
+                                            onChange={(event) =>
+                                                dispatch(
+                                                    uploadActions.setAlternativeValue(
+                                                        {
+                                                            value: event.target
+                                                                .value,
+                                                            index,
+                                                        },
+                                                    ),
+                                                )
+                                            }
                                         />
                                     </div>
                                 ))}

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -12,6 +12,7 @@ import { ReactComponent as SmileFace } from "assets/Svgs/smileFace.svg";
 import { ReactComponent as DownV } from "assets/Svgs/downV.svg";
 import { ReactComponent as LocationIcon } from "assets/Svgs/location.svg";
 import Picker, { IEmojiData } from "emoji-picker-react";
+import UploadImgArrowAndDots from "components/Common/Header/UploadImgArrowAndDots";
 
 const StyledContent = styled.div`
     display: flex;
@@ -20,6 +21,7 @@ const StyledContent = styled.div`
         display: flex;
         justify-content: center;
         align-items: center;
+        position: relative;
     }
     & > .upload__contents {
         width: 340px;
@@ -226,7 +228,6 @@ interface ContentProps {
     currentWidth: number;
 }
 const Content = ({ currentWidth }: ContentProps) => {
-    console.log("rerendered");
     const dispatch = useAppDispatch();
     const {
         files,
@@ -341,6 +342,12 @@ const Content = ({ currentWidth }: ContentProps) => {
                                 ratioMode,
                                 currentWidth,
                             )}
+                        />
+                    )}
+                    {files.length > 1 && (
+                        <UploadImgArrowAndDots
+                            currentIndex={currentIndex}
+                            files={files}
                         />
                     )}
                 </div>

--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -418,7 +418,29 @@ const Content = ({ currentWidth }: ContentProps) => {
                             </span>
                         </div>
                         {isAdvancedOptionOn && (
-                            <div className="activated">hello</div>
+                            <div className="activated">
+                                <div>
+                                    <div>
+                                        이 게시물의 좋아요 수 및 조회수 숨기기
+                                    </div>
+                                    <div></div>
+                                </div>
+                                <div className="smallFont">
+                                    이 게시물의 총 좋아요 및 조회수는 회원님만
+                                    볼 수 있습니다. 나중에 게시물 상단에 있는
+                                    ··· 메뉴에서 이 설정을 변경할 수 있습니다.
+                                    다른 사람의 게시물에서 좋아요 수를 숨기려면
+                                    계정 설정으로 이동하세요.
+                                </div>
+                                <div>
+                                    <div>댓글 기능 해제</div>
+                                    <div></div>
+                                </div>
+                                <div className="smallFont">
+                                    나중에 게시물 상단의 메뉴(···)에서 이 설정을
+                                    변경할 수 있습니다.
+                                </div>
+                            </div>
                         )}
                     </div>
                     <hr />

--- a/src/components/Common/Header/Upload/Cut/Cut.tsx
+++ b/src/components/Common/Header/Upload/Cut/Cut.tsx
@@ -17,14 +17,13 @@ import { ReactComponent as PhotoOutline } from "assets/Svgs/photoOutline.svg";
 import { ReactComponent as SquareCut } from "assets/Svgs/squareCut.svg";
 import { ReactComponent as ThinRectangle } from "assets/Svgs/thinRectangle.svg";
 import { ReactComponent as FatRectangle } from "assets/Svgs/fatRectangle.svg";
-import { ReactComponent as LeftArrow } from "assets/Svgs/leftArrow.svg";
-import { ReactComponent as RightArrow } from "assets/Svgs/rightArrow.svg";
 import { ReactComponent as Delete } from "assets/Svgs/delete.svg";
 import { ReactComponent as PlusIcon } from "assets/Svgs/plus.svg";
 import { uploadActions } from "app/store/ducks/upload/uploadSlice";
 import CutImgUnit from "components/Common/Header/Upload/Cut/CutImgUnit";
 import sprite from "assets/Images/sprite.png";
 import UploadHeader from "components/Common/Header/Upload/UploadHeader";
+import UploadImgArrowAndDots from "components/Common/Header/UploadImgArrowAndDots";
 
 type HandlingType = "ratio" | "resize" | "gallery" | null | "first";
 
@@ -434,45 +433,6 @@ const StyledCut = styled.div<StyledCutProps>`
                     }
                 }
             }
-        }
-    }
-    & > .upload__leftArrow,
-    & > .upload__rightArrow {
-        position: absolute;
-        z-index: 999;
-        background-color: rgba(26, 26, 26, 0.8);
-        width: 32px;
-        height: 32px;
-        border-radius: 50%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        transition: background-color 0.2s;
-        &:hover {
-            background-color: rgba(26, 26, 26, 0.5);
-        }
-    }
-    & > .upload__leftArrow {
-        left: 8px;
-    }
-    & > .upload__rightArrow {
-        right: 8px;
-    }
-    & > .upload__imgDots {
-        position: absolute;
-        bottom: 32px;
-        display: flex;
-        & > div {
-            background-color: ${(props) => props.theme.font.gray};
-            border-radius: 50%;
-            width: 6px;
-            height: 6px;
-            &.current {
-                background-color: ${(props) => props.theme.color.blue};
-            }
-        }
-        & > div:not(:last-child) {
-            margin-right: 4px;
         }
     }
 `;
@@ -1071,56 +1031,24 @@ const Cut = ({ currentWidth }: CutProps) => {
                     </div>
                 </div>
                 {files.length > 1 && (
-                    <>
-                        {currentIndex > 0 && (
-                            <button
-                                className="upload__leftArrow"
-                                onClick={() => {
-                                    setHandlingMode((prev) => {
-                                        return prev !== "first"
-                                            ? null
-                                            : "first";
-                                    });
-                                    toggleInputState(handlingMode);
-                                    fixOverTranformedImage(
-                                        files[currentIndex].scale,
-                                    );
-                                    dispatch(uploadActions.prevIndex());
-                                }}
-                            >
-                                <LeftArrow />
-                            </button>
-                        )}
-                        {currentIndex < files.length - 1 && (
-                            <button
-                                className="upload__rightArrow"
-                                onClick={() => {
-                                    setHandlingMode((prev) => {
-                                        return prev !== "first"
-                                            ? null
-                                            : "first";
-                                    });
-                                    toggleInputState(handlingMode);
-                                    fixOverTranformedImage(
-                                        files[currentIndex].scale,
-                                    );
-                                    dispatch(uploadActions.nextIndex());
-                                }}
-                            >
-                                <RightArrow />
-                            </button>
-                        )}
-                        <div className="upload__imgDots">
-                            {files.map((file, index) => (
-                                <div
-                                    key={file.url}
-                                    className={`${
-                                        currentIndex === index ? "current" : ""
-                                    }`}
-                                ></div>
-                            ))}
-                        </div>
-                    </>
+                    <UploadImgArrowAndDots
+                        currentIndex={currentIndex}
+                        files={files}
+                        onLeftArrowClick={() => {
+                            setHandlingMode((prev) => {
+                                return prev !== "first" ? null : "first";
+                            });
+                            toggleInputState(handlingMode);
+                            fixOverTranformedImage(files[currentIndex].scale);
+                        }}
+                        onRightArrowClick={() => {
+                            setHandlingMode((prev) => {
+                                return prev !== "first" ? null : "first";
+                            });
+                            toggleInputState(handlingMode);
+                            fixOverTranformedImage(files[currentIndex].scale);
+                        }}
+                    />
                 )}
                 <CutImgUnit
                     currentFile={files[currentIndex]}

--- a/src/components/Common/Header/UploadImgArrowAndDots.tsx
+++ b/src/components/Common/Header/UploadImgArrowAndDots.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { ReactComponent as LeftArrow } from "assets/Svgs/leftArrow.svg";
+import { ReactComponent as RightArrow } from "assets/Svgs/rightArrow.svg";
+import styled from "styled-components";
+import { useAppDispatch } from "app/store/Hooks";
+import { uploadActions } from "app/store/ducks/upload/uploadSlice";
+
+const Wrapper = styled.div`
+    & > .upload__leftArrow,
+    & > .upload__rightArrow {
+        transform: translateY(-50%);
+        position: absolute;
+        z-index: 999;
+        background-color: rgba(26, 26, 26, 0.8);
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        transition: background-color 0.2s;
+        &:hover {
+            background-color: rgba(26, 26, 26, 0.5);
+        }
+    }
+    & > .upload__leftArrow {
+        left: 8px;
+    }
+    & > .upload__rightArrow {
+        right: 8px;
+    }
+    & > .upload__imgDots {
+        position: absolute;
+        bottom: 32px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        & > div {
+            background-color: ${(props) => props.theme.font.gray};
+            border-radius: 50%;
+            width: 6px;
+            height: 6px;
+            &.current {
+                background-color: ${(props) => props.theme.color.blue};
+            }
+        }
+        & > div:not(:last-child) {
+            margin-right: 4px;
+        }
+    }
+`;
+
+interface UploadImgArrowAndDotsProps {
+    currentIndex: number;
+    files: UploadType.FileProps[];
+    onLeftArrowClick?: () => void;
+    onRightArrowClick?: () => void;
+}
+
+// 상위 컴포넌트에 position: relative 속성을 추가하여 사용 가능
+// 각 arrow 클릭 시 index 이동 dispatch는 이미 포함되어 있음
+const UploadImgArrowAndDots = ({
+    currentIndex,
+    files,
+    onLeftArrowClick,
+    onRightArrowClick,
+}: UploadImgArrowAndDotsProps) => {
+    const dispatch = useAppDispatch();
+    return (
+        <Wrapper>
+            {currentIndex > 0 && (
+                <button
+                    className="upload__leftArrow"
+                    onClick={() => {
+                        onLeftArrowClick && onLeftArrowClick();
+                        dispatch(uploadActions.prevIndex());
+                    }}
+                >
+                    <LeftArrow />
+                </button>
+            )}
+            {currentIndex < files.length - 1 && (
+                <button
+                    className="upload__rightArrow"
+                    onClick={() => {
+                        onRightArrowClick && onRightArrowClick();
+                        dispatch(uploadActions.nextIndex());
+                    }}
+                >
+                    <RightArrow />
+                </button>
+            )}
+            <div className="upload__imgDots">
+                {files.map((file, index) => (
+                    <div
+                        key={file.url}
+                        className={`${currentIndex === index ? "current" : ""}`}
+                    ></div>
+                ))}
+            </div>
+        </Wrapper>
+    );
+};
+
+export default UploadImgArrowAndDots;

--- a/src/components/Home/SearchListItem.tsx
+++ b/src/components/Home/SearchListItem.tsx
@@ -1,6 +1,7 @@
 import { getSearchRecord } from "app/store/ducks/common/commonThunk";
 import { useAppDispatch } from "app/store/Hooks";
 import CloseSVG from "assets/Svgs/CloseSVG";
+import SearchListItemLayout from "components/Home/SearchListItemLayout";
 import { authorizedCustomAxios } from "customAxios";
 import React, { Dispatch, SetStateAction } from "react";
 import { Link } from "react-router-dom";
@@ -10,37 +11,7 @@ import theme from "styles/theme";
 const Container = styled.div`
     display: flex;
     a {
-        display: flex;
-        align-items: center;
-        gap: 20px;
-        height: 60px;
-        padding: 8px 16px;
-        cursor: pointer;
         text-decoration: none;
-        &:hover {
-            background-color: ${theme.color.bg_gray};
-        }
-
-        .profile-image {
-            width: 44px;
-            height: 44px;
-            border-radius: 50%;
-        }
-
-        .profile-contents {
-            .username {
-                font-weight: 600;
-            }
-            .name-container {
-                span {
-                    color: ${theme.font.gray};
-                }
-                .name {
-                }
-                .follow-info {
-                }
-            }
-        }
     }
 `;
 
@@ -79,24 +50,10 @@ const SearchListItem = ({
     return (
         <Container>
             <Link to={`/profile/${member.username}`} onClick={userClickHandler}>
-                <img
-                    src={member.image.imageUrl}
-                    alt="member"
-                    className="profile-image"
+                <SearchListItemLayout
+                    member={member}
+                    followingMemberFollow={followingMemberFollow}
                 />
-                <div className="profile-contents">
-                    <span className="username">{member.username}</span>
-                    <div className="name-container">
-                        <span className="name">{member.name}</span>
-                        {followingMemberFollow && (
-                            <span className="follow-info">
-                                •{followingMemberFollow[0].memberUsername} 외{" "}
-                                {followingMemberFollow.length - 1}명이
-                                팔로우합니다
-                            </span>
-                        )}
-                    </div>
-                </div>
             </Link>
             {button && (
                 <button onClick={removeUserHandler}>

--- a/src/components/Home/SearchListItemLayout.tsx
+++ b/src/components/Home/SearchListItemLayout.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import styled from "styled-components";
+
+const StyledSearchListItemLayout = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    height: 60px;
+    padding: 8px 16px;
+    cursor: pointer;
+    text-decoration: none;
+    &:hover {
+        background-color: ${(props) => props.theme.color.bg_gray};
+    }
+
+    .profile-image {
+        width: 44px;
+        height: 44px;
+        border-radius: 50%;
+    }
+
+    .profile-contents {
+        .username {
+            font-weight: 600;
+        }
+        .name-container {
+            span {
+                color: ${(props) => props.theme.font.gray};
+            }
+            .name {
+            }
+            .follow-info {
+            }
+        }
+    }
+`;
+
+interface SearchUserLayoutProps {
+    member: Common.memberType;
+    followingMemberFollow?: { memberUsername: string }[];
+}
+
+const SearchListItemLayout = ({
+    member,
+    followingMemberFollow,
+}: SearchUserLayoutProps) => {
+    return (
+        <StyledSearchListItemLayout>
+            <img
+                src={member.image.imageUrl}
+                alt="member"
+                className="profile-image"
+            />
+            <div className="profile-contents">
+                <span className="username">{member.username}</span>
+                <div className="name-container">
+                    <span className="name">{member.name}</span>
+                    {followingMemberFollow && (
+                        <span className="follow-info">
+                            •{followingMemberFollow[0].memberUsername} 외{" "}
+                            {followingMemberFollow.length - 1}명이 팔로우합니다
+                        </span>
+                    )}
+                </div>
+            </div>
+        </StyledSearchListItemLayout>
+    );
+};
+
+export default SearchListItemLayout;


### PR DESCRIPTION
## 개요
마지막 Content 단계에 이미지 관련 branch입니다

## 작업사항
파일이 여러 개인 경우 보여줘야 하는 현재 index에 대한 정보를 시각적으로 보여줘야 하므로 화살표와, 점을 활용하였습니다.
또한 이미지 각각에 해시태그를 달 수 있도록 할 예정입니다.

## 주요 변경 로직

- [x] Cut 단계와 동일하게 LeftArrow, RightArrow, imgDots 를 적용

hashtag

- [x] 선택된 username이 상대적 위치에 검은 말풍선 형태로 위치
- [x] 말풍선 오른쪽 x 버튼 클릭시 해당 해시태그 삭제
- [ ] 이미지 끝자락에 검은 말풍선이 걸릴 경우 포인터만 유지한 채 content가 걸리지 않도록 이동
- [ ] searchModal을 이미지 절반 밑일 경우 화살표 위쪽에 위치하도록
- [ ] searchModal이 켜져있을 때 left,rightArrow 클릭 시 이동하지 않고 searchModal이 사라짐