### PR TITLE
Feature/sub nav in header

### DIFF
--- a/src/components/Common/Header/NavItems.tsx
+++ b/src/components/Common/Header/NavItems.tsx
@@ -44,6 +44,10 @@ const NavItemWrapper = styled.div`
 `;
 
 const AvatarWrapper = styled(NavItemWrapper)<{ isSubnavModalOn: boolean }>`
+    .profile {
+        cursor: pointer;
+    }
+
     .img-container {
         display: flex;
         justify-content: center;
@@ -141,6 +145,7 @@ const NavItems = () => {
                         onClick={() => {
                             setIsSubnavMoalOn(!isSubnavModalOn);
                         }}
+                        className="profile"
                     >
                         <div className="img-container">
                             <img

--- a/src/components/Profile/Modals/SettingModal.tsx
+++ b/src/components/Profile/Modals/SettingModal.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import ModalCard from "styles/UI/ModalCard";
 import styled from "styled-components";
+import { useAppDispatch } from "app/store/Hooks";
+import { logout } from "app/store/ducks/auth/authThunk";
 
 const SettingModalInner = styled.div`
     display: flex;
@@ -27,6 +29,7 @@ interface SettingModalProps {
 }
 
 const SettingModal = ({ onModalOn, onModalOff }: SettingModalProps) => {
+    const dispatch = useAppDispatch();
     return (
         <ModalCard
             modalType="withBackDrop"
@@ -42,7 +45,7 @@ const SettingModal = ({ onModalOn, onModalOff }: SettingModalProps) => {
                 <div>로그인 활동</div>
                 <div>Instagram에서 보낸 이메일</div>
                 <div>문제 신고</div>
-                <div>로그아웃</div>
+                <div onClick={() => dispatch(logout())}>로그아웃</div>
                 <div onClick={onModalOff}>취소</div>
             </SettingModalInner>
         </ModalCard>


### PR DESCRIPTION
## 작업사항
- 헤더, 프로필에 hover할 때 cursor pointer로 적용 
- 마이프로필 페이지, 톱니바퀴(설정)클릭해 보이는 모달에서, 로그아웃 api 연결 

### 참고 
로그아웃 api가 feature/sub-nav-in-header에 구현해뒀어서 이 브랜치에서 같이 작업했는데, 
develop에 머지해둬서 따로 브랜치 파서 작업하는 게 보기 좋았을 거 같네요! 
다음부터 브랜치 나눠서 커밋하도록 의식하겠습니다! 
