### PR TITLE
fix: home article의 이미지 슬라이더 개선

### DIFF
--- a/src/components/Home/Article/ArticleImgSlider/ArticleImgSlider.tsx
+++ b/src/components/Home/Article/ArticleImgSlider/ArticleImgSlider.tsx
@@ -159,6 +159,9 @@ const ArticleImgSlider = ({ imageDTOs, onLike }: ArticleImgSliderProps) => {
     };
 
     useEffect(() => {
+        wrapRef.current?.scrollBy({
+            left: 0,
+        });
         window.addEventListener("resize", resizeHandler);
         resizeHandler();
         return () => {

--- a/src/components/Home/Article/ArticleImgSlider/ArticleImgSlider.tsx
+++ b/src/components/Home/Article/ArticleImgSlider/ArticleImgSlider.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import sprite2 from "assets/Images/sprite2.png";
 import styled from "styled-components";
 import ArticleImgSliderUnit from "components/Home/Article/ArticleImgSlider/ArticleImgSliderUnit";
@@ -148,9 +148,23 @@ const ArticleImgSlider = ({ imageDTOs, onLike }: ArticleImgSliderProps) => {
     //slider state
     const [sliderIndex, setSliderIndex] = useState(0);
     const [doubleClicked, setDoubleClicked] = useState(false);
+    const [unitWidth, setUnitWidth] = useState(0);
     const totalIndex = imageDTOs.length - 1;
     const wrapRef = useRef<HTMLDivElement>(null);
     const sliderRef = useRef<HTMLDivElement>(null);
+
+    const resizeHandler = () => {
+        if (!wrapRef.current) return;
+        setUnitWidth(wrapRef.current.offsetWidth);
+    };
+
+    useEffect(() => {
+        window.addEventListener("resize", resizeHandler);
+        resizeHandler();
+        return () => {
+            window.removeEventListener("resize", resizeHandler);
+        };
+    }, []);
 
     const doubleClickLikeHandler = () => {
         setDoubleClicked(true);
@@ -212,11 +226,16 @@ const ArticleImgSlider = ({ imageDTOs, onLike }: ArticleImgSliderProps) => {
                 ></div>
             )}
             <div className="img-wrap" ref={wrapRef} onScroll={detectScroll}>
-                <div className="img-slider" ref={sliderRef}>
+                <div
+                    className="img-slider"
+                    ref={sliderRef}
+                    style={{ width: imageDTOs.length * 100 + "%" }}
+                >
                     {imageDTOs.map((imageDTO) => (
                         <ArticleImgSliderUnit
                             key={imageDTO.id}
                             imageDTO={imageDTO}
+                            unitWidth={unitWidth}
                         />
                     ))}
                 </div>

--- a/src/components/Home/Article/ArticleImgSlider/ArticleImgSlider.tsx
+++ b/src/components/Home/Article/ArticleImgSlider/ArticleImgSlider.tsx
@@ -243,9 +243,10 @@ const ArticleImgSlider = ({ imageDTOs, onLike }: ArticleImgSliderProps) => {
             <div className="leftArrow" onClick={leftArrowClickHandler}></div>
             <div className="rightArrow" onClick={rightArrowClickHandler}></div>
             <div className="img-dots">
-                {[...Array(totalIndex + 1)].map((a, index) => (
-                    <div key={index} className="img-dot" />
-                ))}
+                {totalIndex > 0 &&
+                    [...Array(totalIndex + 1)].map((a, index) => (
+                        <div key={index} className="img-dot" />
+                    ))}
             </div>
         </StyledImgSlider>
     );

--- a/src/components/Home/Article/ArticleImgSlider/ArticleImgSliderUnit.tsx
+++ b/src/components/Home/Article/ArticleImgSlider/ArticleImgSliderUnit.tsx
@@ -29,16 +29,19 @@ const StyledArticleImgSliderUnit = styled.div`
     }
 `;
 
+interface ArticleImgSliderUnitProps {
+    imageDTO: Common.PostImageDTOProps;
+    unitWidth: number;
+}
+
 const ArticleImgSliderUnit = ({
     imageDTO,
-}: {
-    imageDTO: Common.PostImageDTOProps;
-}) => {
+    unitWidth,
+}: ArticleImgSliderUnitProps) => {
     const [isAvatarOn, setIsAvatarOn] = useState(false);
     const [isImgHashTagsOn, setIsImgHashTagOn] = useState<boolean | null>(null);
-    const [timeoutId, setTimeoutId] = useState<null | ReturnType<
-        typeof setTimeout
-    >>(null);
+    const [timeoutId, setTimeoutId] =
+        useState<null | ReturnType<typeof setTimeout>>(null);
 
     const onClickHandler = () => {
         if (!isAvatarOn) {
@@ -85,7 +88,11 @@ const ArticleImgSliderUnit = ({
                         isImgHashTagsOn={isImgHashTagsOn}
                     />
                 ))}
-            <img src={imageDTO.postImageUrl} alt={imageDTO.postImageUrl} />
+            <img
+                src={imageDTO.postImageUrl}
+                alt={imageDTO.postImageUrl}
+                width={unitWidth}
+            />
         </StyledArticleImgSliderUnit>
     );
 };


### PR DESCRIPTION
## 개요
이미지 비율이 다양해지면서 기존에 만들어두었던 home article의 이미지들의 비율이 깨지는 현상을 수정합니다.(fix)

초반에 home을 구현할 때는 몰랐으나, 한 게시글을 업로드할 때 **모든 이미지들은 모두 비율이 같게** 조정됩니다. 기존 강아지 사진들은 최근 구현 완료된 uploadForm을 통해 업로드한 것이 아니라 비율이 제각각인 점 참고해주세요!

## 작업사항
이미지 비율에 모두 대응되도록 이미지 레이아웃 수정 및 slider 개선

## 주요 변경 로직

- [x] home article 이미지들이 비율에 대응되도록 수정
- [x] 이미지가 하나일 때 dots가 안 보이도록 수정
- [x] 첫 렌더링 완료 시 첫 번째 이미지가 보이지 않는 문제 수정
