### PR TITLE
UploadForm waringModal

### DIFF
--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -303,6 +303,8 @@ declare module UploadType {
     interface UploadStateProps {
         isUploading: boolean;
         isGrabbing: boolean;
+        isWarningModalOn: boolean;
+        isJustWarningBeforePrevStep: boolean;
         step: StepType;
         ratioMode: RatioType;
         files: FileProps[];

--- a/src/app/store/ducks/upload/uploadSlice.ts
+++ b/src/app/store/ducks/upload/uploadSlice.ts
@@ -25,9 +25,6 @@ const uploadSlice = createSlice({
         cancelUpload: (state) => {
             return initialState;
         },
-        toCutStep: (state) => {
-            state.step = "cut";
-        },
         prevStep: (state) => {
             switch (state.step) {
                 case "dragAndDrop":

--- a/src/app/store/ducks/upload/uploadSlice.ts
+++ b/src/app/store/ducks/upload/uploadSlice.ts
@@ -3,6 +3,8 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 const initialState: UploadType.UploadStateProps = {
     isUploading: false,
     isGrabbing: false,
+    isWarningModalOn: false,
+    isJustWarningBeforePrevStep: false,
     step: "dragAndDrop",
     ratioMode: "square",
     files: [],
@@ -31,7 +33,6 @@ const uploadSlice = createSlice({
                 case "dragAndDrop":
                     return initialState;
                 case "cut":
-                    // 나중에 경고 모달 필요
                     state.files.forEach((file) =>
                         window.URL.revokeObjectURL(file.url),
                     );
@@ -290,6 +291,20 @@ const uploadSlice = createSlice({
         },
         addEmojiOnTextarea: (state, action: PayloadAction<string>) => {
             state.textareaValue += action.payload;
+        },
+        startWarningModal: (state) => {
+            state.isWarningModalOn = true;
+        },
+        notificateWarningIsJustAboutBeforePrevStep: (state) => {
+            state.isJustWarningBeforePrevStep = true;
+        },
+        // excuteFunctionAfterWarning: (state) => {
+        //     state.isWarningModalOn = false;
+        //     state.functionAfterWarning && state.functionAfterWarning();
+        // },
+        cancelWarningModal: (state) => {
+            state.isWarningModalOn = false;
+            state.isJustWarningBeforePrevStep = false;
         },
     },
 });

--- a/src/components/Common/Header/Upload/Cut/Cut.tsx
+++ b/src/components/Common/Header/Upload/Cut/Cut.tsx
@@ -757,9 +757,13 @@ const Cut = ({ currentWidth }: CutProps) => {
     return (
         <>
             <UploadHeader
-                excuteBeforePrevStep={() =>
-                    fixOverTranformedImage(files[currentIndex].scale)
-                }
+                excuteBeforePrevStep={() => {
+                    fixOverTranformedImage(files[currentIndex].scale);
+                    dispatch(uploadActions.startWarningModal());
+                    dispatch(
+                        uploadActions.notificateWarningIsJustAboutBeforePrevStep(),
+                    );
+                }}
                 excuteBeforeNextStep={() =>
                     fixOverTranformedImage(files[currentIndex].scale)
                 }

--- a/src/components/Common/Header/Upload/DragAndDrop/DragAndDrop.tsx
+++ b/src/components/Common/Header/Upload/DragAndDrop/DragAndDrop.tsx
@@ -96,7 +96,7 @@ const DragAndDrop = () => {
                     }),
                 );
                 if (index === droppedFiles.length - 1) {
-                    dispatch(uploadActions.toCutStep());
+                    dispatch(uploadActions.nextStep());
                 }
             };
         });
@@ -120,7 +120,7 @@ const DragAndDrop = () => {
                     }),
                 );
                 if (index === addedFiles.length - 1) {
-                    dispatch(uploadActions.toCutStep());
+                    dispatch(uploadActions.nextStep());
                 }
             };
         });

--- a/src/components/Common/Header/Upload/Upload.tsx
+++ b/src/components/Common/Header/Upload/Upload.tsx
@@ -35,6 +35,7 @@ const Upload = () => {
     const isGrabbing = useAppSelector(({ upload }) => upload.isGrabbing);
     const [backDropwidth, setBackDropWidth] = useState(window.innerWidth);
     const [backDropHeight, setBackDropHeight] = useState(window.innerHeight);
+    const [isWarningModalOn, setIsWarningModalOn] = useState(false);
     const currentWidth = useMemo(
         () => (backDropwidth < 1140 ? backDropwidth - 219 : 920),
         [backDropwidth],
@@ -101,41 +102,53 @@ const Upload = () => {
         if (isGrabbing) {
             dispatch(uploadActions.stopGrabbing());
         } else {
-            dispatch(uploadActions.cancelUpload());
+            setIsWarningModalOn(true);
+            // dispatch(uploadActions.cancelUpload());
         }
     };
 
     return (
-        <ModalCard
-            modalType="withBackDrop"
-            onModalOn={() => dispatch(uploadActions.startUpload())}
-            onModalOff={checkIsGrabbingAndCancelUpload}
-            isWithCancelBtn={true}
-            width={
-                currentWidthLimitedByWindowHeight +
-                (step !== "edit" && step !== "content" ? 0 : 340)
-            }
-            height={currentHeightLimitedByWindowHeight}
-            maxWidth={
-                currentMaxWidth +
-                BORDER_TOTAL_WIDTH +
-                (step !== "edit" && step !== "content" ? 0 : 340)
-            }
-            maxHeight={currentMaxWidth + BORDER_TOTAL_WIDTH + 43}
-            minWidth={
-                348 +
-                BORDER_TOTAL_WIDTH +
-                (step !== "edit" && step !== "content" ? 0 : 340)
-            }
-            minHeight={391 + BORDER_TOTAL_WIDTH}
-        >
-            <StyledUploadModalInner
-                backdropWidth={backDropwidth}
-                onMouseUp={() => dispatch(uploadActions.stopGrabbing())}
+        <>
+            {isWarningModalOn && (
+                <ModalCard
+                    modalType="withBackDrop"
+                    onModalOn={() => setIsWarningModalOn(true)}
+                    onModalOff={() => setIsWarningModalOn(false)}
+                >
+                    warning
+                </ModalCard>
+            )}
+            <ModalCard
+                modalType="withBackDrop"
+                onModalOn={() => dispatch(uploadActions.startUpload())}
+                onModalOff={checkIsGrabbingAndCancelUpload}
+                isWithCancelBtn={true}
+                width={
+                    currentWidthLimitedByWindowHeight +
+                    (step !== "edit" && step !== "content" ? 0 : 340)
+                }
+                height={currentHeightLimitedByWindowHeight}
+                maxWidth={
+                    currentMaxWidth +
+                    BORDER_TOTAL_WIDTH +
+                    (step !== "edit" && step !== "content" ? 0 : 340)
+                }
+                maxHeight={currentMaxWidth + BORDER_TOTAL_WIDTH + 43}
+                minWidth={
+                    348 +
+                    BORDER_TOTAL_WIDTH +
+                    (step !== "edit" && step !== "content" ? 0 : 340)
+                }
+                minHeight={391 + BORDER_TOTAL_WIDTH}
             >
-                {currentComponent(step)}
-            </StyledUploadModalInner>
-        </ModalCard>
+                <StyledUploadModalInner
+                    backdropWidth={backDropwidth}
+                    onMouseUp={() => dispatch(uploadActions.stopGrabbing())}
+                >
+                    {currentComponent(step)}
+                </StyledUploadModalInner>
+            </ModalCard>
+        </>
     );
 };
 

--- a/src/components/Common/Header/Upload/Upload.tsx
+++ b/src/components/Common/Header/Upload/Upload.tsx
@@ -8,6 +8,39 @@ import Cut from "components/Common/Header/Upload/Cut";
 import Edit from "components/Common/Header/Upload/Edit";
 import Content from "components/Common/Header/Upload/Content";
 
+const StyledUploadWarningModalInner = styled.div`
+    width: 100%;
+    & * {
+        text-align: center;
+    }
+    & > .warning__header {
+        margin: 32px 32px 16px 32px;
+        & > h3 {
+            font-weight: ${(props) => props.theme.font.bold};
+            font-size: 18px;
+        }
+        & > div {
+            padding-top: 16px;
+            color: ${(props) => props.theme.font.gray};
+        }
+    }
+    & > .warning__delete,
+    & > .warning__cancel {
+        display: block;
+        width: 100%;
+        border-top: 1px solid ${(props) => props.theme.color.bd_gray};
+        padding: 4px 8px;
+        line-height: 40px;
+        min-height: 48px;
+    }
+    & > .warning__delete {
+        margin-top: 16px;
+        color: ${(props) => props.theme.font.red};
+    }
+    & > .warning__cancel {
+        font-weight: normal;
+    }
+`;
 interface ModalInnerProps {
     backdropWidth: number;
 }
@@ -115,7 +148,16 @@ const Upload = () => {
                     onModalOn={() => setIsWarningModalOn(true)}
                     onModalOff={() => setIsWarningModalOn(false)}
                 >
-                    warning
+                    <StyledUploadWarningModalInner>
+                        <div className="warning__header">
+                            <h3>게시물을 삭제하시겠어요?</h3>
+                            <div>
+                                지금 나가면 수정 내용이 저장되지 않습니다.
+                            </div>
+                        </div>
+                        <button className="warning__delete">삭제</button>
+                        <button className="warning__cancel">취소</button>
+                    </StyledUploadWarningModalInner>
                 </ModalCard>
             )}
             <ModalCard

--- a/src/components/Common/Header/Upload/Upload.tsx
+++ b/src/components/Common/Header/Upload/Upload.tsx
@@ -7,40 +7,8 @@ import DragAndDrop from "components/Common/Header/Upload/DragAndDrop";
 import Cut from "components/Common/Header/Upload/Cut";
 import Edit from "components/Common/Header/Upload/Edit";
 import Content from "components/Common/Header/Upload/Content";
+import UploadWarningModal from "components/Common/Header/Upload/UploadWarningModal";
 
-const StyledUploadWarningModalInner = styled.div`
-    width: 100%;
-    & * {
-        text-align: center;
-    }
-    & > .warning__header {
-        margin: 32px 32px 16px 32px;
-        & > h3 {
-            font-weight: ${(props) => props.theme.font.bold};
-            font-size: 18px;
-        }
-        & > div {
-            padding-top: 16px;
-            color: ${(props) => props.theme.font.gray};
-        }
-    }
-    & > .warning__delete,
-    & > .warning__cancel {
-        display: block;
-        width: 100%;
-        border-top: 1px solid ${(props) => props.theme.color.bd_gray};
-        padding: 4px 8px;
-        line-height: 40px;
-        min-height: 48px;
-    }
-    & > .warning__delete {
-        margin-top: 16px;
-        color: ${(props) => props.theme.font.red};
-    }
-    & > .warning__cancel {
-        font-weight: normal;
-    }
-`;
 interface ModalInnerProps {
     backdropWidth: number;
 }
@@ -66,9 +34,11 @@ const Upload = () => {
     const dispatch = useAppDispatch();
     const step = useAppSelector(({ upload }) => upload.step);
     const isGrabbing = useAppSelector(({ upload }) => upload.isGrabbing);
+    const isWarningModalOn = useAppSelector(
+        ({ upload }) => upload.isWarningModalOn,
+    );
     const [backDropwidth, setBackDropWidth] = useState(window.innerWidth);
     const [backDropHeight, setBackDropHeight] = useState(window.innerHeight);
-    const [isWarningModalOn, setIsWarningModalOn] = useState(false);
     const currentWidth = useMemo(
         () => (backDropwidth < 1140 ? backDropwidth - 219 : 920),
         [backDropwidth],
@@ -135,31 +105,13 @@ const Upload = () => {
         if (isGrabbing) {
             dispatch(uploadActions.stopGrabbing());
         } else {
-            setIsWarningModalOn(true);
-            // dispatch(uploadActions.cancelUpload());
+            dispatch(uploadActions.startWarningModal());
         }
     };
 
     return (
         <>
-            {isWarningModalOn && (
-                <ModalCard
-                    modalType="withBackDrop"
-                    onModalOn={() => setIsWarningModalOn(true)}
-                    onModalOff={() => setIsWarningModalOn(false)}
-                >
-                    <StyledUploadWarningModalInner>
-                        <div className="warning__header">
-                            <h3>게시물을 삭제하시겠어요?</h3>
-                            <div>
-                                지금 나가면 수정 내용이 저장되지 않습니다.
-                            </div>
-                        </div>
-                        <button className="warning__delete">삭제</button>
-                        <button className="warning__cancel">취소</button>
-                    </StyledUploadWarningModalInner>
-                </ModalCard>
-            )}
+            {isWarningModalOn && <UploadWarningModal />}
             <ModalCard
                 modalType="withBackDrop"
                 onModalOn={() => dispatch(uploadActions.startUpload())}

--- a/src/components/Common/Header/Upload/UploadHeader/UploadHeader.tsx
+++ b/src/components/Common/Header/Upload/UploadHeader/UploadHeader.tsx
@@ -58,11 +58,10 @@ const UploadHeader = ({
     }, []);
 
     const prevStepClickHandler = () => {
-        if (excuteBeforePrevStep) {
-            excuteBeforePrevStep();
-        }
-        dispatch(uploadActions.prevStep());
+        if (excuteBeforePrevStep) excuteBeforePrevStep();
+        if (step !== "cut") dispatch(uploadActions.prevStep());
     };
+
     const nextStepClickHandler = () => {
         if (excuteBeforeNextStep) {
             excuteBeforeNextStep();

--- a/src/components/Common/Header/Upload/UploadWarningModal.tsx
+++ b/src/components/Common/Header/Upload/UploadWarningModal.tsx
@@ -1,0 +1,84 @@
+import { uploadActions } from "app/store/ducks/upload/uploadSlice";
+import { useAppDispatch, useAppSelector } from "app/store/Hooks";
+import React from "react";
+import styled from "styled-components";
+import ModalCard from "styles/UI/ModalCard";
+
+const StyledUploadWarningModalInner = styled.div`
+    width: 100%;
+    & * {
+        text-align: center;
+    }
+    & > .warning__header {
+        margin: 32px 32px 16px 32px;
+        & > h3 {
+            font-weight: ${(props) => props.theme.font.bold};
+            font-size: 18px;
+        }
+        & > div {
+            padding-top: 16px;
+            color: ${(props) => props.theme.font.gray};
+        }
+    }
+    & > .warning__delete,
+    & > .warning__cancel {
+        display: block;
+        width: 100%;
+        border-top: 1px solid ${(props) => props.theme.color.bd_gray};
+        padding: 4px 8px;
+        line-height: 40px;
+        min-height: 48px;
+    }
+    & > .warning__delete {
+        margin-top: 16px;
+        color: ${(props) => props.theme.font.red};
+    }
+    & > .warning__cancel {
+        font-weight: normal;
+    }
+`;
+
+const UploadWarningModal = () => {
+    const isJustWarningBeforePrevStep = useAppSelector(
+        ({ upload }) => upload.isJustWarningBeforePrevStep,
+    );
+    const dispatch = useAppDispatch();
+
+    const deleteBtnClickHandler = () => {
+        if (isJustWarningBeforePrevStep) {
+            dispatch(uploadActions.prevStep());
+        } else {
+            console.log("그냥 뒤로");
+            dispatch(uploadActions.cancelUpload());
+        }
+    };
+
+    return (
+        <ModalCard
+            modalType="withBackDrop"
+            onModalOn={() => dispatch(uploadActions.startWarningModal())}
+            onModalOff={() => dispatch(uploadActions.cancelWarningModal())}
+        >
+            <StyledUploadWarningModalInner>
+                <div className="warning__header">
+                    <h3>게시물을 삭제하시겠어요?</h3>
+                    <div>지금 나가면 수정 내용이 저장되지 않습니다.</div>
+                </div>
+                <button
+                    className="warning__delete"
+                    onClick={deleteBtnClickHandler}
+                >
+                    삭제
+                </button>
+                <button
+                    className="warning__cancel"
+                    onClick={() => dispatch(uploadActions.cancelWarningModal())}
+                >
+                    취소
+                </button>
+            </StyledUploadWarningModalInner>
+        </ModalCard>
+    );
+};
+
+export default UploadWarningModal;


### PR DESCRIPTION
## 개요
uploadForm을 끄려고 할 때 보여줄 주의사항 모달입니다.

## 구현 사항
레이아웃(ui)
- [x] UploadWarningModal 레이아웃 구현

모달에 연결한 기능
redux 전역 state를 활용하여 구현하였습니다.
- [x] UploadForm 밖 부분을 클릭하였을 때 or `cut` step에서 "뒤로 가기" 화살표를 클릭하였을 때 UploadWarningModal이 활성화 되도록 구현
- [x] UploadForm 바깥 부분을 클릭하여 활성화되었을 경우 "삭제" 버튼을 누르면 uploadForm을 끄도록 구현
- [x] `cut` step에서 "뒤로 가기" 화살표(`prevStep`)를 눌러 활성화 되었을 때는 "삭제" 버튼을 누르면 uploadForm은 끄지 않고 이전 단계로 감과 동시에 `files` 데이터만 초기화해주도록 구현