### PR TITLE
feat: 해시태그 검색 추가

### DIFF
--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -337,12 +337,18 @@ declare module Common {
         hasStory: boolean;
     }
 
-    interface searchUserType {
-        dtype: "MEMBER";
-        follwer: boolean;
-        following: boolean;
-        followingMemberFollow: { memberUsername: string }[];
-        member: memberType;
+    interface searchResultType {
+        dtype: "MEMBER" | "HASHTAG";
+
+        // MEMBER
+        follwer?: boolean;
+        following?: boolean;
+        followingMemberFollow?: { memberUsername: string }[];
+        member?: memberType;
+
+        // HASHTAG
+        name?: string;
+        postCount?: number;
     }
     interface PostImageDTOProps {
         id: number;

--- a/src/app/store/ducks/common/commonSlice.ts
+++ b/src/app/store/ducks/common/commonSlice.ts
@@ -4,8 +4,8 @@ import { getSearchRecord, searchUser } from "./commonThunk";
 export interface InitialStateType {
     isLoading: boolean;
     searchUserKeyword: string;
-    searchUsers: Common.searchUserType[];
-    recordedUsers: Common.searchUserType[];
+    searchUsers: Common.searchResultType[];
+    recordedUsers: Common.searchResultType[];
 }
 
 const initialState: InitialStateType = {

--- a/src/app/store/ducks/common/commonThunk.ts
+++ b/src/app/store/ducks/common/commonThunk.ts
@@ -5,7 +5,7 @@ import { FAIL_TO_REISSUE_MESSAGE } from "utils/constant";
 import { authAction } from "../auth/authSlice";
 
 export const searchUser = createAsyncThunk<
-    Common.searchUserType[],
+    Common.searchResultType[],
     {
         keyword: string;
     },
@@ -17,18 +17,12 @@ export const searchUser = createAsyncThunk<
             params: { text: payload.keyword },
         };
         try {
-            const myUsername = getState().auth.userInfo?.memberUsername;
-
             const { data } = await authorizedCustomAxios.get(
                 `/topsearch`,
                 config,
             );
 
-            // 검색해서 나온 결과중에 자기 자신을 제외해줍니다.
-            return data.data.filter(
-                (user: Common.searchUserType) =>
-                    user.member.username !== myUsername,
-            );
+            return data.data;
         } catch (error) {
             error === FAIL_TO_REISSUE_MESSAGE && dispatch(authAction.logout());
             throw rejectWithValue(error);
@@ -37,23 +31,18 @@ export const searchUser = createAsyncThunk<
 );
 
 export const getSearchRecord = createAsyncThunk<
-    Common.searchUserType[],
+    Common.searchResultType[],
     void,
     { state: RootState }
 >(
     "common/getSearchRecord",
     async (payload, { getState, dispatch, rejectWithValue }) => {
         try {
-            const myUsername = getState().auth.userInfo?.memberUsername;
-
             const { data } = await authorizedCustomAxios.get(
                 "/topsearch/recent/top",
             );
 
-            return data.data.content.filter(
-                (user: Common.searchUserType) =>
-                    user.member.username !== myUsername,
-            );
+            return data.data.content;
         } catch (error) {
             error === FAIL_TO_REISSUE_MESSAGE && dispatch(authAction.logout());
             throw rejectWithValue(error);

--- a/src/components/Common/Header/SearchBar.tsx
+++ b/src/components/Common/Header/SearchBar.tsx
@@ -58,6 +58,7 @@ const SearchBarContainer = styled.div`
         .recent-container {
             display: flex;
             flex-direction: column;
+            width: 100%;
             .header {
                 padding: 8px 16px;
                 display: flex;
@@ -160,10 +161,10 @@ const SearchBar = () => {
                                         모두 지우기
                                     </button>
                                 </div>
-                                {recordedUsers.map((user) => (
+                                {recordedUsers.map((item) => (
                                     <SearchListItem
-                                        key={user.member.id}
-                                        {...user}
+                                        key={item.member?.username || item.name}
+                                        {...item}
                                         setIsFocused={setIsFocused}
                                         button
                                     />
@@ -173,10 +174,10 @@ const SearchBar = () => {
 
                         {/* 실제 검색시에 나오게 되는 화면 */}
                         {searchUsers.length > 0 &&
-                            searchUsers.map((user) => (
+                            searchUsers.map((item) => (
                                 <SearchListItem
-                                    key={user.member.id}
-                                    {...user}
+                                    key={item.member?.username || item.name}
+                                    {...item}
                                     setIsFocused={setIsFocused}
                                 />
                             ))}

--- a/src/components/Direct/Section/Modals/NewChatModal/NewChatFriendList.tsx
+++ b/src/components/Direct/Section/Modals/NewChatModal/NewChatFriendList.tsx
@@ -33,9 +33,15 @@ const NewChatFriendList = () => {
             <span>추천</span>
 
             <div className="new-chat-recommend-container">
-                {searchUsers.map((user) => (
-                    <NewChatRecommendUser key={user.member.id} {...user} />
-                ))}
+                {searchUsers.map(
+                    (user) =>
+                        user.member && (
+                            <NewChatRecommendUser
+                                key={user.member.id}
+                                {...user}
+                            />
+                        ),
+                )}
             </div>
         </NewChatFriendListContainer>
     );

--- a/src/components/Direct/Section/Modals/NewChatModal/NewChatRecommendUser.tsx
+++ b/src/components/Direct/Section/Modals/NewChatModal/NewChatRecommendUser.tsx
@@ -41,16 +41,17 @@ const NewChatRecommendUserContainer = styled.div`
     }
 `;
 
-const NewChatRecommendUser = ({ member }: Common.searchUserType) => {
+const NewChatRecommendUser = ({ member }: Common.searchResultType) => {
     const { selectedNewChatUsers } = useAppSelector((state) => state.direct);
     const dispatch = useAppDispatch();
+    if (!member) return null;
 
     const selectNewChatUserHandler = () => {
         // 이미 선택했다면 제거해줍니다.
-        if (selectedNewChatUsers.includes(member.username)) {
-            dispatch(unSelectNewChatUser(member.username));
+        if (selectedNewChatUsers.includes(member?.username)) {
+            dispatch(unSelectNewChatUser(member?.username));
         } else {
-            dispatch(selectNewChatUser(member.username));
+            dispatch(selectNewChatUser(member?.username));
             dispatch(changeSearchUser(""));
         }
     };

--- a/src/components/Home/SearchListItem.tsx
+++ b/src/components/Home/SearchListItem.tsx
@@ -9,8 +9,10 @@ import theme from "styles/theme";
 
 const Container = styled.div`
     display: flex;
+    width: 100%;
     a {
         display: flex;
+        width: 328px;
         align-items: center;
         gap: 20px;
         height: 60px;
@@ -42,28 +44,38 @@ const Container = styled.div`
             }
         }
     }
+
+    .close-button {
+        flex: 1;
+    }
 `;
 
-interface SearchListItemProps extends Common.searchUserType {
+interface SearchListItemProps extends Common.searchResultType {
     setIsFocused: Dispatch<SetStateAction<boolean>>;
     button?: boolean;
 }
 
 const SearchListItem = ({
+    dtype,
     member,
     followingMemberFollow,
     setIsFocused,
     button,
+    name,
+    postCount,
 }: SearchListItemProps) => {
     const dispatch = useAppDispatch();
 
     // 공통으로 사용하는 config
     const config = {
-        params: { entityName: member.username, entityType: "MEMBER" },
+        params: {
+            entityName: member?.username || `#${name}`,
+            entityType: dtype,
+        },
     };
 
-    // 사람을 클릭하여 그 사람 프로필로 이동
-    const userClickHandler = async () => {
+    // 사람을 클릭하여 그 사람 프로필로 이동 혹은 해시태그 클릭
+    const itemClickHandler = async () => {
         // 조회수 증가
         await authorizedCustomAxios.post("/topsearch/mark", null, config);
         // 모달끄기
@@ -78,28 +90,59 @@ const SearchListItem = ({
 
     return (
         <Container>
-            <Link to={`/profile/${member.username}`} onClick={userClickHandler}>
-                <img
-                    src={member.image.imageUrl}
-                    alt="member"
-                    className="profile-image"
-                />
-                <div className="profile-contents">
-                    <span className="username">{member.username}</span>
-                    <div className="name-container">
-                        <span className="name">{member.name}</span>
-                        {followingMemberFollow && (
-                            <span className="follow-info">
-                                •{followingMemberFollow[0].memberUsername} 외{" "}
-                                {followingMemberFollow.length - 1}명이
-                                팔로우합니다
-                            </span>
-                        )}
+            {dtype === "MEMBER" ? (
+                <Link
+                    to={`/profile/${member?.username}`}
+                    onClick={itemClickHandler}
+                >
+                    <img
+                        src={member?.image.imageUrl}
+                        alt="member"
+                        className="profile-image"
+                    />
+                    <div className="profile-contents">
+                        <span className="username">{member?.username}</span>
+                        <div className="name-container">
+                            <span className="name">{member?.name}</span>
+                            {followingMemberFollow &&
+                                followingMemberFollow.length > 0 && (
+                                    <span className="follow-info">
+                                        •
+                                        {
+                                            followingMemberFollow[0]
+                                                .memberUsername
+                                        }{" "}
+                                        외 {followingMemberFollow.length - 1}
+                                        명이 팔로우합니다
+                                    </span>
+                                )}
+                        </div>
                     </div>
-                </div>
-            </Link>
+                </Link>
+            ) : (
+                <Link to={`/hashtag/${name}`} onClick={itemClickHandler}>
+                    <img
+                        src={
+                            "https://user-images.githubusercontent.com/69495129/178100078-a0570a9c-99c8-4d67-b4d9-e589df0a4ab9.png"
+                        }
+                        alt="hashtag"
+                        className="profile-image"
+                    />
+                    <div className="profile-contents">
+                        {name && <span className="username">#{name}</span>}
+                        <div className="name-container">
+                            <span className="name">{member?.name}</span>
+                            {
+                                <span className="follow-info">
+                                    게시물 {postCount}
+                                </span>
+                            }
+                        </div>
+                    </div>
+                </Link>
+            )}
             {button && (
-                <button onClick={removeUserHandler}>
+                <button onClick={removeUserHandler} className="close-button">
                     <CloseSVG color={theme.font.gray} size={"18"} />
                 </button>
             )}

--- a/src/customAxios.ts
+++ b/src/customAxios.ts
@@ -13,11 +13,11 @@ export const authorizedCustomAxios: AxiosInstance = axios.create({
 });
 
 export const checkToken = async (config: AxiosRequestConfig) => {
-
     const accessToken =
         authorizedCustomAxios.defaults.headers.common.Authorization.split(
             " ",
         )[1];
+    console.log(accessToken);
     const decode = jwt.decode(accessToken);
     const nowDate = new Date().getTime() / 1000;
     if (decode.exp < nowDate) {


### PR DESCRIPTION
## 개요

- 기존에 유저만 검색되던 것을 해시태그도 검색하도록 추가하였습니다.

## 작업사항

-   

## 주요 변경 로직

-   기존에 존재하던 searchUser 라는 thunk function 안에서 사용하였습니다.

## 질문
해시태그를 클릭하면 라우팅될 링크를 정해야합니다.
일단은
<Link to={`/hashtag/${name}`} /> 으로  처리해 두었습니다.

