### PR TITLE
fix: upload navItem을 클릭해도 home으로 redirect되지 않도록 수정

### DIFF
--- a/src/components/Common/Header/NavItems.tsx
+++ b/src/components/Common/Header/NavItems.tsx
@@ -41,6 +41,9 @@ const NavItemWrapper = styled.div`
     & + & {
         margin-left: 22px;
     }
+    & > div {
+        cursor: pointer;
+    }
 `;
 
 const AvatarWrapper = styled(NavItemWrapper)<{ isSubnavModalOn: boolean }>`
@@ -135,7 +138,17 @@ const NavItems = () => {
                 {isUploading && <Upload />}
                 {navItems.map((navItem) => (
                     <NavItemWrapper key={navItem.id}>
-                        <NavLink to={navItem.path}>{navItem.component}</NavLink>
+                        {navItem.id === "새 글 작성" ? (
+                            <div>
+                                {isUploading
+                                    ? navItem.activeComponent
+                                    : navItem.component}
+                            </div>
+                        ) : (
+                            <NavLink to={navItem.path}>
+                                {navItem.component}
+                            </NavLink>
+                        )}
                     </NavItemWrapper>
                 ))}
 


### PR DESCRIPTION
## 개요
navItems 중 upload item을 클릭했을 때 home으로 redirect되는 문제를 해결하였습니다.

## 주요 변경 로직
- [x] upload item 클릭시 active component를 보여주도록 하고 그냥 현 route를 유지한 채 모달만 띄우도록 함
