### PR TITLE
hotfix/auth: 백엔드 유저인증 변경사항 적용 

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -67,7 +67,7 @@ const AuthedContainer = () => {
             <Route path="/profile/:username" component={Profile} />
             <Route path="/accounts/edit" component={Edit} />
 
-            <Route exact path="/" component={Home} />
+            <Route exact path="/" component={Edit} />
             {/* Direct */}
             <Route path="/direct" component={Direct} />
             {/* 404 페이지 필요*/}

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -67,7 +67,7 @@ const AuthedContainer = () => {
             <Route path="/profile/:username" component={Profile} />
             <Route path="/accounts/edit" component={Edit} />
 
-            <Route exact path="/" component={Edit} />
+            <Route exact path="/" component={Home} />
             {/* Direct */}
             <Route path="/direct" component={Direct} />
             {/* 404 페이지 필요*/}

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -49,6 +49,9 @@ const Routes = () => {
                             path="/accounts/password/reset/confirm"
                             component={ResetPasswordForm}
                         />
+                        <Route path="/error">
+                            <h1>404 page</h1>
+                        </Route>
                         <Redirect to="/" />
                     </Switch>
                 )}

--- a/src/app/store/ducks/auth/authThunk.ts
+++ b/src/app/store/ducks/auth/authThunk.ts
@@ -100,16 +100,12 @@ export const resetPassword = createAsyncThunk<
 export const signInUseCode = createAsyncThunk<
     AuthType.Token,
     { code: string; username: string }
->("auth/signInUseCode", async (payload) => {
-    try {
-        const { data } = await customAxios.post(`/accounts/login/recovery`, {
-            code: payload.code,
-            username: payload.username,
-        });
-        return data.data;
-    } catch {
-        // 에러나는 경우? username, code가 잘못됐을 때?
-    }
+>("auth/signInUseCode", async (payload, ThunkOptions) => {
+    const { data } = await customAxios.post(`/login/recovery`, {
+        code: payload.code,
+        username: payload.username,
+    });
+    return data.data;
 });
 
 export const logout = createAsyncThunk<void, void>(

--- a/src/components/Auth/Suggest.tsx
+++ b/src/components/Auth/Suggest.tsx
@@ -25,8 +25,6 @@ const routerMessageState = {
 
 export default function Suggest() {
     const formState = useAppSelector((state) => state.auth.currentFormState);
-    console.log(formState);
-
     const [question, suggest, linkRouter] =
         routerMessageState[formState === "signIn" ? "signin" : "emailsignup"];
 

--- a/src/components/Auth/Suggest.tsx
+++ b/src/components/Auth/Suggest.tsx
@@ -25,6 +25,8 @@ const routerMessageState = {
 
 export default function Suggest() {
     const formState = useAppSelector((state) => state.auth.currentFormState);
+    console.log(formState);
+
     const [question, suggest, linkRouter] =
         routerMessageState[formState === "signIn" ? "signin" : "emailsignup"];
 

--- a/src/customAxios.ts
+++ b/src/customAxios.ts
@@ -6,6 +6,7 @@ export const customAxios: AxiosInstance = axios.create({
     baseURL: `http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080`,
     withCredentials: true,
 });
+// customAxios interceptor -> url: reissue, method: post인 케이스만 따로 처리 **
 
 export const authorizedCustomAxios: AxiosInstance = axios.create({
     baseURL: `http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080`,
@@ -21,6 +22,7 @@ export const checkToken = async (config: AxiosRequestConfig) => {
     const decode = jwt.decode(accessToken);
     const nowDate = new Date().getTime() / 1000;
     if (decode.exp < nowDate) {
+        // FIXME: ! 바꿔야한디 !
         try {
             const {
                 data: { data },
@@ -36,8 +38,13 @@ export const checkToken = async (config: AxiosRequestConfig) => {
                 }
             }
         } catch (error) {
-            // 토큰재발급 실패한 경우(refresh token만료)
-            window.location.replace("/");
+            // 토큰재발급 실패한 경우(refreshToken 쿠키 제거 - httpOnly쿠키라, 백엔드에서만 제거가능)
+            customAxios.post(`/logout/only/cookie`);
+            // 새로고침 => 토큰 재발급 불필요하게 호출 **
+            // TODO: want : isLogin = false;
+            // access token을 처리할 필요는 없어. 왜냐면 access token이 만료돼서 호출한 토큰재발급이 실패한거니까
+            // 근데 문제는, 제거한다고, 바로 로그인페이지로 안가. 왜냐고? isLogin이 바뀌지 않잖아.
+            // 그럼 계속 홈에 있을거고, 계속 여기로와서 저 api를 계속 호출하고, 실제로 유저가 보기엔 먹통이겠지?
         }
     }
     return config;

--- a/src/customAxios.ts
+++ b/src/customAxios.ts
@@ -6,7 +6,6 @@ export const customAxios: AxiosInstance = axios.create({
     baseURL: `http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080`,
     withCredentials: true,
 });
-// customAxios interceptor -> url: reissue, method: post인 케이스만 따로 처리 **
 
 export const authorizedCustomAxios: AxiosInstance = axios.create({
     baseURL: `http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com:8080`,
@@ -14,7 +13,6 @@ export const authorizedCustomAxios: AxiosInstance = axios.create({
 });
 
 export const checkToken = async (config: AxiosRequestConfig) => {
-
     const accessToken =
         authorizedCustomAxios.defaults.headers.common.Authorization.split(
             " ",
@@ -22,7 +20,6 @@ export const checkToken = async (config: AxiosRequestConfig) => {
     const decode = jwt.decode(accessToken);
     const nowDate = new Date().getTime() / 1000;
     if (decode.exp < nowDate) {
-        // FIXME: ! 바꿔야한디 !
         try {
             const {
                 data: { data },
@@ -40,11 +37,7 @@ export const checkToken = async (config: AxiosRequestConfig) => {
         } catch (error) {
             // 토큰재발급 실패한 경우(refreshToken 쿠키 제거 - httpOnly쿠키라, 백엔드에서만 제거가능)
             customAxios.post(`/logout/only/cookie`);
-            // 새로고침 => 토큰 재발급 불필요하게 호출 **
-            // TODO: want : isLogin = false;
-            // access token을 처리할 필요는 없어. 왜냐면 access token이 만료돼서 호출한 토큰재발급이 실패한거니까
-            // 근데 문제는, 제거한다고, 바로 로그인페이지로 안가. 왜냐고? isLogin이 바뀌지 않잖아.
-            // 그럼 계속 홈에 있을거고, 계속 여기로와서 저 api를 계속 호출하고, 실제로 유저가 보기엔 먹통이겠지?
+            window.location.replace("/"); // FIXME: 새로고침 => 토큰 재발급 불필요하게 호출 **
         }
     }
     return config;

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -3,10 +3,11 @@ import { useAppDispatch } from "app/store/Hooks";
 import Form from "components/Auth/Form";
 import { Footer } from "components/Common/Footer/Footer";
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import queryString from "query-string";
 import { signInUseCode } from "app/store/ducks/auth/authThunk";
+import InstagramLoading from "InstagramLoading";
 
 const Section = styled.section`
     flex-shrink: 0;
@@ -22,24 +23,42 @@ const Section = styled.section`
 
 export default function AuthPage(props: { router: "signIn" | "signUp" }) {
     const dispatch = useAppDispatch();
+    const history = useHistory();
     const { search } = useLocation();
     const { username, code } = queryString.parse(
         search,
     ) as AuthType.resetPasswordQuery;
 
     useEffect(() => {
-        if (props.router === "signIn") {
-            dispatch(signInUseCode({ username, code }));
+        const checkLoginUseCode = async () => {
+            try {
+                await dispatch(signInUseCode({ username, code })).unwrap();
+                history.push("/");
+            } catch (error) {
+                // 에러인 경우(만료된 code) => 404페이지(만료된 페이지입니다)
+                history.push("/error");
+            }
+        };
+
+        if (username && code) {
+            checkLoginUseCode();
+        } else {
+            dispatch(authAction.changeFormState(props.router));
         }
-        dispatch(authAction.changeFormState(props.router));
     }, []);
 
     return (
-        <Section>
-            <main className="form-container">
-                <Form router={props.router} />
-            </main>
-            <Footer />
-        </Section>
+        <>
+            {username && code ? (
+                <InstagramLoading />
+            ) : (
+                <Section>
+                    <main className="form-container">
+                        <Form router={props.router} />
+                    </main>
+                    <Footer />
+                </Section>
+            )}
+        </>
     );
 }

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -45,7 +45,7 @@ export default function AuthPage(props: { router: "signIn" | "signUp" }) {
         } else {
             dispatch(authAction.changeFormState(props.router));
         }
-    }, []);
+    }, [props.router]);
 
     return (
         <>


### PR DESCRIPTION
## 관련 이슈
https://github.com/Instagram-Clone-Coding/React_instagram_clone/issues/71

## 작업사항
-  비밀번호 재설정 > 코드를 통한 로그인 
    - 엔드포인트 적용 
    - 코드를 통한 로그인 후, url 변경 적용   
       (코드를 통한 로그인은 url query값을 이용해 호출한 후, home 페이지를 보여줘야하기에 url 을 /(루트)로 바꾸는 로직 추가함) 
- reissue(토큰재발급) 호출 실패 시, 만료된 refresh token만 제거하는 api(이번에 만들어주신 api)로 변경함 
- formState 변경 문제 있어서 수정함. useEffect 디펜던시 문제였음 

## 주요 변경 로직
- 노션에 자세하게 적으면서 수정했습니다.   
자세한건 [노션](https://peaceful-litter-6ad.notion.site/7561d95dff434f2f9a4df758c1d169d1)의 관리브랜치 > 유저인증 > done 토글 탭을 참고 부탁드립니다. 


## 고민 
파일: `src > customAxios.ts`
1.  reissue(토큰 재발급) 호출 실패
2. access, refresh 둘 다 만료된 것 
3. refresh 제거 api 호출 
4. isLogin = false로 변경해야하는데, 
isLogin = false를 인터셉터 안에서는 호출할 수 없어서 어떻게 처리해야할지 고민입니다. 

일단, 전역상태값은 새로고침 시 초기값이 되기에, (3) refresh 제거 api 호출 후, 새로고침 시켜뒀습니다. 
하지만 이럴 경우에, 토큰 재발급 api를 불필요하게 호출하게 됩니다. 
(로그인 후에 다시 재방문했을 때, 로그인 후의 페이지를 보여주기 위해 최상단에서 토큰 재발급 api를 호출하기 때문입니다) 

@kimyoungyin 영인님이 제안주신 customAxios(토큰재발급을 호출하는 axios 인스턴스)에 인터셉터를 이용하는 방법도 생각해봤습니다. 
그래도, 인터셉터 내에서는 전역상태값 접근이 안되다보니.. customAxios에서 처리해야하는 이유는 찾지못했습니다 😢 
