### PR TITLE
fix: 프로필 맨 아래 큰 이미지 삭제

### DIFF
--- a/src/components/Common/Header/Upload/Content/Content.tsx
+++ b/src/components/Common/Header/Upload/Content/Content.tsx
@@ -214,7 +214,6 @@ const Content = ({ currentWidth }: ContentProps) => {
                             // URL.revokeObjectURL(url);
                         };
                         newImg.src = url;
-                        document.body.appendChild(newImg);
                     });
                 };
             }


### PR DESCRIPTION
## 개요
#86 
큰 이미지가 프로필 페이지 맨 아래 뜨지 않도록 수정하였습니다

