### PR TITLE
비밀번호 재설정 기능 버그 수정 

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -70,6 +70,7 @@ const AuthedContainer = () => {
             <Route exact path="/" component={Home} />
             {/* Direct */}
             <Route path="/direct" component={Direct} />
+            <Redirect to="/" />
             {/* 404 페이지 필요*/}
         </>
     );

--- a/src/app/store/ducks/auth/authSlice.ts
+++ b/src/app/store/ducks/auth/authSlice.ts
@@ -4,7 +4,6 @@ import {
     getUserInfo,
     signIn,
     resetPassword,
-    checkCurrentURL,
     signInUseCode,
     logout,
 } from "./authThunk";
@@ -124,9 +123,6 @@ const authSlice = createSlice({
             })
             .addCase(resetPassword.rejected, (state) => {
                 state.errorMessage = `전에 사용한 적 없는 새로운 비밀번호를 만드세요.`;
-            })
-            .addCase(checkCurrentURL.rejected, (state) => {
-                // 유효하지 않은 url **
             })
             .addCase(logout.fulfilled, (state) => {
                 state.isLogin = false;

--- a/src/app/store/ducks/auth/authThunk.ts
+++ b/src/app/store/ducks/auth/authThunk.ts
@@ -63,22 +63,14 @@ export const getUserInfo = createAsyncThunk<AuthType.UserInfo>(
 export const checkCurrentURL = createAsyncThunk<
     void,
     { code: string; username: string }
->("auth/checkResetPassword", async (payload, ThunkOptions) => {
-    try {
-        const config = {
-            params: {
-                code: payload.code,
-                username: payload.username,
-            },
-        };
-        const { data } = await customAxios.get(
-            `/accounts/password/reset`,
-            config,
-        );
-        console.log(data);
-    } catch (error) {
-        throw ThunkOptions.rejectWithValue(error);
-    }
+>("auth/checkResetPassword", async (payload) => {
+    const config = {
+        params: {
+            code: payload.code,
+            username: payload.username,
+        },
+    };
+    await customAxios.get(`/accounts/password/reset`, config);
 });
 
 export const resetPassword = createAsyncThunk<

--- a/src/components/Auth/ResetPassword/ResetPasswordForm.tsx
+++ b/src/components/Auth/ResetPassword/ResetPasswordForm.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import queryString from "query-string";
 import HeaderBeforeLogin from "./HeaderBeforeLogin";
 import ContentBox from "components/Common/ContentBox";
@@ -77,6 +77,7 @@ export default function ResetPasswordForm() {
         search,
     ) as AuthType.resetPasswordQuery;
     const dispatch = useAppDispatch();
+    const history = useHistory();
     const { errorMessage } = useAppSelector((state) => state.auth);
 
     const [newPasswordInputProps, newPasswordIsValid] = useInput(
@@ -92,7 +93,11 @@ export default function ResetPasswordForm() {
     );
 
     useEffect(() => {
-        dispatch(checkCurrentURL({ code, username }));
+        dispatch(checkCurrentURL({ code, username }))
+            .unwrap()
+            .catch(() => {
+                history.push("/error");
+            });
     }, []);
 
     const resetPasswordClickHandler = (


### PR DESCRIPTION
## 🧊 관련이슈 
#88 

## 👨‍💻 작업사항
### 메일 > 비밀번호 재설정, 코드 유효하지 않을 때 에러페이지로 대응 
- 비밀번호 재설정 메일을 보낸 후, 몇분 간만 재설정 페이지에 접근할 수 있음 (이를 코드로 체크함) 
    - 코드가 유효하지 않을 때, 만료된 코드입니다을 보여주는 에러페이지로 이동해야함. 
    - 아직 에러페이지를 만들진 않았고, 간단하게 만들어 놓은 에러페이지 router 로 이동시켰음. 
    - 필요한 에러페이지 만든 후, 라우터 연결하면 될 거 같습니다. 

### 메일 > 비밀번호 재설정 > 완료 후, url을 "/"로 이동
- 비밀번호 재설정을 성공적으로 끝내면, 바꾼 비밀번호로 자동 로그인이 되어 home이 보여야 함
   - 라우터를 / 로 처리하지 않아 home이 보이지 않아서 이를 처리해야했음. 
   - 로그인 후, 없는 라우터에 대해 redirect /로 처리함 


## 💬 참고해주세요  
### 로그인 후, 없는 라우터에 대해 redirect / 처리 
로그인 유무와 상관없이 정의하지 않은 라우터에 대해서 리다이렉트 루트로 처리했었는데, 
로그인 후에는 리다이렉트 루트처리할 필요가 없을 거 같다고 해서, 해당 코드를 지웠습니다. 
그런데, 없는 라우터에 대해 home으로 리다이렉트 할 경우가 생겨서 이번에 추가했는데, 어떻게 생각하시나요??
- 방법1) 이렇게 되면, 저희가 처리할 에러페이지를 라우터에 대응해놓고, 그 밑에 리다이렉트 홈으로 둬서 
저희가 처리하지 않은 페이지에 대해서는 home으로 돌아가게 됩니다! 
- 방법2) 리다이렉트 처리하지 않고, 처리하지 않은 페이지를 에러페이지로 대응하는 방법도 있습니다! 

