### PR TITLE
fix: 게시물 타입 관련 코드 수정

### DIFF
--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -167,7 +167,9 @@ declare module HomeType {
         postUploadDate: string;
         hashtagsOfContent: string[];
         mentionsOfContent: string[];
-        // comment 몇 개 가져오기
+        likeOptionFlag: boolean; // 업로드한 사람만 좋아요 및 좋아요한 사람 확인 가능
+        commentOptionFlag: boolean; // 댓글 작성 가능 여부
+        // recentComments: string[]; 내부 객체 구조
     }
 
     interface ArticleStateProps extends ArticleProps {

--- a/src/components/Home/Article/Article.tsx
+++ b/src/components/Home/Article/Article.tsx
@@ -37,11 +37,10 @@ const ArticleCard = styled(Card)`
 interface ArticleComponentPros {
     article: HomeType.ArticleStateProps;
     isObserving: boolean;
-    isLast: boolean;
 }
 
 // 아마 여기 articleData는 상위 HomeSection 컴포넌트에서 가져와야 하지 않을까
-const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
+const Article = ({ article, isObserving }: ArticleComponentPros) => {
     // data state
     const followingUserWhoLikesArticle =
         article.followingMemberUsernameLikedPost;
@@ -68,7 +67,6 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
         };
 
         isObserving && isVisible && dispatchExtraArticle(); // 이 때 비동기 작업 및 무한 스크롤
-        // isLast && isVisible && dispatchExtraArticle();
     }, [isObserving, isVisible, dispatch]);
 
     const dispatchPostLike = async () => {
@@ -142,12 +140,15 @@ const Article = ({ article, isObserving, isLast }: ArticleComponentPros) => {
                 commentsCount={article.postCommentsCount}
                 mentions={article.mentionsOfContent}
                 hashtags={article.hashtagsOfContent}
+                likeOptionFlag={article.likeOptionFlag}
                 // comments={article.comments}
             />
             <div className="article-createdAt">{gapText}</div>
-            <div className="article-form-layout">
-                <CommentForm />
-            </div>
+            {!article.commentOptionFlag && (
+                <div className="article-form-layout">
+                    <CommentForm />
+                </div>
+            )}
         </ArticleCard>
     );
 };

--- a/src/components/Home/Article/ArticleMain.tsx
+++ b/src/components/Home/Article/ArticleMain.tsx
@@ -54,6 +54,7 @@ interface MainProps {
     }[];
     mentions: string[];
     hashtags: string[];
+    likeOptionFlag: boolean;
 }
 
 const ArticleMain = ({
@@ -67,6 +68,7 @@ const ArticleMain = ({
     comments,
     mentions,
     hashtags,
+    likeOptionFlag,
 }: MainProps) => {
     // like state
     const [isComment1Liked, setIsComment1Liked] = useState(false); // 백엔드에서 이 코멘트 좋아요 한 사람 중 내가 있는지 확인
@@ -166,24 +168,26 @@ const ArticleMain = ({
     };
 
     const getFullText = () => setIsFullText(true);
+
     return (
         <StyledMain>
-            <div className="article-likeInfo">
-                {followingUserWhoLikesArticle ? (
-                    <div>
-                        {/* 임의로 첫 번째 인덱스 선택 */}
-                        <Username
-                            onMouseEnter={mouseEnterHandler}
-                            onMouseLeave={mouseLeaveHandler}
-                        >
-                            {followingUserWhoLikesArticle}
-                        </Username>
-                        님 외<span>{likesCount - 1}명</span>이 좋아합니다
-                    </div>
-                ) : (
-                    <span>좋아요 {likesCount}개</span>
-                )}
-            </div>
+            {!likeOptionFlag && (
+                <div className="article-likeInfo">
+                    {followingUserWhoLikesArticle ? (
+                        <div>
+                            <Username
+                                onMouseEnter={mouseEnterHandler}
+                                onMouseLeave={mouseLeaveHandler}
+                            >
+                                {followingUserWhoLikesArticle}
+                            </Username>
+                            님 외<span>{likesCount - 1}명</span>이 좋아합니다
+                        </div>
+                    ) : (
+                        <span>좋아요 {likesCount}개</span>
+                    )}
+                </div>
+            )}
             <div className="article-textBox">
                 <Username
                     onMouseEnter={mouseEnterHandler}

--- a/src/components/Home/HomeSection.tsx
+++ b/src/components/Home/HomeSection.tsx
@@ -25,7 +25,6 @@ const HomeSection = () => {
                         key={article.postId}
                         article={article}
                         isObserving={articles.length - 4 === index}
-                        isLast={articles.length - 1 === index}
                     />
                 ))}
             {isExtraArticleLoading && <ExtraLoadingCircle />}


### PR DESCRIPTION
## 개요
게시물에 대해 타입 관련 수정이 필요하였습니다.
- [x] 좋아요/조회수 숨김 or 댓글 작성 가능 여부를 article에 반영
- [x] 댓글 작성 가능 여부 반영
- [ ] 댓글 타입 선언


## 작업사항
업로드 시 해당 값들을 백엔드에 전달해주는 것까지는 완성했었는데, 받아오는 data에 대한 반영을 해주지 않았었네요... 양이 얼마 안되니 확인 부탁드립니다.

## 주요 변경 로직

- [x] index.d.ts에 state를 추가
- [x] `likeOptionFlag`가 false인 경우 좋아요와 조회수 조회 가능하도록 수정
- [x] `commentOptionFlag`가 false인 경우만 댓글 ui가 보이도록 수정
- [ ] 댓글 타입 설정
- [x] 필요없는 `isLast` prop 제거
