### PR TITLE
fix: ArticleHeader에서 팔로우 버튼을 활성화시키는 조건 오류 수정

### DIFF
--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -151,7 +151,7 @@ const ArticleHeader = ({
 
     const followHandler = () => {
         const followUser = async () => {
-            await dispatch(postFollow({ username: memberUsername }));
+            await dispatch(postFollow({ username: memberNickname }));
         };
         followUser();
     };
@@ -176,19 +176,18 @@ const ArticleHeader = ({
                             {memberNickname}
                         </Link>
                     </Username>
-                    {memberNickname !== myUsername &&
-                        (!isFollowing || (
-                            <div className="header-followBox">
-                                <span>•</span>
-                                <button onClick={followHandler}>
-                                    {followLoading ? (
-                                        <Loading size={18} />
-                                    ) : (
-                                        "팔로우"
-                                    )}
-                                </button>
-                            </div> // 로딩 처리 필요
-                        ))}
+                    {memberNickname !== myUsername && !isFollowing && (
+                        <div className="header-followBox">
+                            <span>•</span>
+                            <button onClick={followHandler}>
+                                {followLoading ? (
+                                    <Loading size={18} />
+                                ) : (
+                                    "팔로우"
+                                )}
+                            </button>
+                        </div> // 로딩 처리 필요
+                    )}
                 </div>
                 <Link to={`/explore/locations/:id/${location}`}>
                     {/* location id */}


### PR DESCRIPTION
## 개요

`ArticleHeader` 내 팔로우 버튼이 활성화되는 조건문이 잘못되어 있어 수정하였습니다. 와중에 컴포넌트 내부에 postFollow에 전달되는 객체에 닉네임이 아닌 username이 들어가있어 수정하였습니다.
