### PR TITLE
fix: ArticleHeader 팔로우 버튼 텍스트가 윈도우에서도 잘리지 않도록 수정

### DIFF
--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -42,7 +42,6 @@ const StyledArticleHeader = styled.header`
                 display: flex;
                 justify-content: center;
                 align-items: center;
-                width: 40px;
                 margin-left: 2px;
                 color: ${(props) => props.theme.color.blue};
             }

--- a/src/components/Home/Article/ArticleHeader.tsx
+++ b/src/components/Home/Article/ArticleHeader.tsx
@@ -42,7 +42,7 @@ const StyledArticleHeader = styled.header`
                 display: flex;
                 justify-content: center;
                 align-items: center;
-                width: 36.34px;
+                width: 40px;
                 margin-left: 2px;
                 color: ${(props) => props.theme.color.blue};
             }


### PR DESCRIPTION
## 작업사항

-   `ArticleHeader` 팔로우 버튼 텍스트가 윈도우에서는 잘려서 width를 40px로 증가