### PR TITLE
fix: 회원가입 정규표현식 올바르게 수정

### DIFF
--- a/src/components/Auth/SignUpForm/validator.ts
+++ b/src/components/Auth/SignUpForm/validator.ts
@@ -7,11 +7,15 @@ const lengthScopeValidator = (
     return Length >= minLength && Length <= maxLength;
 };
 
+const hasSpecialChar = (value: string) => {
+    const hasSpecialChar = /[^0-9a-zA-Z]/g;
+    return hasSpecialChar.test(value);
+};
+
 export const emailFormValidator = (email: string): boolean => {
-    const reg =
+    const emailFormat =
         /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
-    const matchResult = email.match(reg);
-    return matchResult === null ? false : true;
+    return emailFormat.test(email);
 };
 
 export const nameValidator = (name: string): boolean => {
@@ -23,11 +27,7 @@ export const usernameValidator = (username: string): boolean => {
         return false;
     }
 
-    const reg = /[0-9a-zA-Z]+/g;
-    if (username.match(reg) === null) {
-        return false;
-    }
-    return true;
+    return !hasSpecialChar(username);
 };
 
 export const passwordValidator = (password: string): boolean => {
@@ -35,9 +35,11 @@ export const passwordValidator = (password: string): boolean => {
         return false;
     }
 
-    if (!/\d+/g.test(password)) {
+    if (hasSpecialChar(password)) {
         return false;
     }
 
-    return true;
+    // 숫자,영어 최소 1개 있는지 체크하는 정규식
+    // 참고) https://stackoverflow.com/questions/7684815/regex-pattern-to-match-at-least-1-number-and-1-character-in-a-string
+    return /(?=.*[0-9])(?=.*[a-zA-Z])([a-zA-Z0-9]+)/.test(password);
 };

--- a/src/components/Auth/SignUpForm/validator.ts
+++ b/src/components/Auth/SignUpForm/validator.ts
@@ -8,8 +8,8 @@ const lengthScopeValidator = (
 };
 
 const hasSpecialChar = (value: string) => {
-    const hasSpecialChar = /[^0-9a-zA-Z]/g;
-    return hasSpecialChar.test(value);
+    const specialChar = /[^0-9a-zA-Z]/g;
+    return specialChar.test(value);
 };
 
 export const emailFormValidator = (email: string): boolean => {


### PR DESCRIPTION
## 개요
#109 

## 작업사항
- 회원가입 시 받는 값, 잘못된 정규표현식 수정 
  - username: 특수문자 있는지 체크 (있다면 false) 
  - password: 특수문자 있는지 체크, 숫자, 영어 최소 1개 있는지 체크 

