### PR TITLE
fix, refactor: 모든 routes에 사용되는 modal들을 routes에 위치

### DIFF
--- a/src/ModalsInEveryRoutes.tsx
+++ b/src/ModalsInEveryRoutes.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { modalActions } from "app/store/ducks/modal/modalSlice";
+import Notification from "styles/UI/Notification";
+import HoverModal from "components/Home/Modals/HoverModal";
+import FollowingModal from "components/Home/Modals/FollowingModal";
+import ArticleMenuModal from "components/Home/Modals/ArticleMenuModal";
+import ReportModal from "components/Home/Modals/ReportModal";
+import ShareWithModal from "components/Home/Modals/SharerWithModal";
+import { useAppDispatch, useAppSelector } from "app/store/Hooks";
+
+const ModalsInEveryRoutes = () => {
+    const {
+        home: { isCopiedNotification },
+        modal: {
+            activatedModal,
+            memberNickname,
+            postId,
+            miniProfile,
+            memberImageUrl,
+        },
+    } = useAppSelector((state) => state);
+
+    const dispatch = useAppDispatch();
+
+    const hoverModalMouseEnterHandler = () => {
+        dispatch(modalActions.mouseOnHoverModal());
+    };
+    const hoverModalMouseLeaveHandler = () => {
+        dispatch(modalActions.mouseNotOnHoverModal());
+        setTimeout(() => dispatch(modalActions.checkMouseOnHoverModal()), 500);
+    };
+
+    return (
+        <>
+            {isCopiedNotification && (
+                <Notification text="링크를 클립보드에 복사했습니다." />
+            )}
+            {miniProfile && (
+                <HoverModal
+                    onMouseEnter={hoverModalMouseEnterHandler}
+                    onMouseLeave={hoverModalMouseLeaveHandler}
+                    miniProfile={miniProfile}
+                />
+            )}
+            {activatedModal === "unfollowing" && (
+                <FollowingModal
+                    onModalOn={() => {
+                        dispatch(modalActions.maintainModalon("unfollowing"));
+                    }}
+                    onModalOff={() =>
+                        dispatch(modalActions.changeActivatedModal(null))
+                    }
+                    memberImageUrl={memberImageUrl}
+                    memberNickname={memberNickname}
+                />
+            )}
+            {activatedModal === "articleMenu" && memberNickname && postId && (
+                <ArticleMenuModal
+                    onModalOn={() =>
+                        dispatch(modalActions.maintainModalon("articleMenu"))
+                    }
+                    onModalOff={() => dispatch(modalActions.resetModal())}
+                />
+            )}
+            {/* 아래 두 모달은 이전 모달을 거쳐야 하므로 필요없는 data는 action에 담지 않음 */}
+            {activatedModal === "report" && (
+                <ReportModal
+                    onModalOn={() =>
+                        dispatch(modalActions.maintainModalon("report"))
+                    }
+                    onModalOff={() => dispatch(modalActions.resetModal())}
+                />
+            )}
+            {activatedModal === "shareWith" && (
+                <ShareWithModal
+                    onModalOn={() =>
+                        dispatch(modalActions.maintainModalon("shareWith"))
+                    }
+                    onModalOff={() => dispatch(modalActions.resetModal())}
+                />
+            )}
+        </>
+    );
+};
+
+export default ModalsInEveryRoutes;

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -10,6 +10,7 @@ import AuthPage from "pages/Auth";
 import ResetPassword from "components/Auth/ResetPassword";
 import ResetPasswordForm from "components/Auth/ResetPassword/ResetPasswordForm";
 import Edit from "pages/Edit";
+import ModalsInEveryRoutes from "ModalsInEveryRoutes";
 
 const Routes = () => {
     const isLogin = useAppSelector((state) => state.auth.isLogin);
@@ -17,6 +18,7 @@ const Routes = () => {
     return (
         <>
             <BrowserRouter basename={process.env.PUBLIC_URL}>
+                {/* <ModalsInEveryRoutes /> */}
                 {/* {!isLogin ? (
                     <Redirect to="/accounts/signin" />
                 ) : (
@@ -63,6 +65,8 @@ const Routes = () => {
 const AuthedContainer = () => {
     return (
         <>
+            <ModalsInEveryRoutes />
+
             <Header />
             <Route path="/profile/:username" component={Profile} />
             <Route path="/accounts/edit" component={Edit} />

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -18,7 +18,6 @@ const Routes = () => {
     return (
         <>
             <BrowserRouter basename={process.env.PUBLIC_URL}>
-                {/* <ModalsInEveryRoutes /> */}
                 {/* {!isLogin ? (
                     <Redirect to="/accounts/signin" />
                 ) : (

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -2,6 +2,9 @@ import styled from "styled-components";
 import HomeAside from "components/Home/HomeAside";
 import HomeStories from "components/Home/HomeStories";
 import HomeSection from "components/Home/HomeSection";
+import { useEffect } from "react";
+import { useAppDispatch } from "app/store/Hooks";
+import { modalActions } from "app/store/ducks/modal/modalSlice";
 
 const Layout = styled.div`
     padding-top: 30px;
@@ -25,6 +28,13 @@ const Layout = styled.div`
 `;
 
 const Home = () => {
+    const dispatch = useAppDispatch();
+    useEffect(() => {
+        return () => {
+            dispatch(modalActions.resetModal());
+        };
+    }, [dispatch]);
+
     return (
         <Layout>
             <main>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -2,14 +2,6 @@ import styled from "styled-components";
 import HomeAside from "components/Home/HomeAside";
 import HomeStories from "components/Home/HomeStories";
 import HomeSection from "components/Home/HomeSection";
-import Notification from "styles/UI/Notification";
-import { useAppDispatch, useAppSelector } from "app/store/Hooks";
-import HoverModal from "components/Home/Modals/HoverModal";
-import FollowingModal from "components/Home/Modals/FollowingModal";
-import ArticleMenuModal from "components/Home/Modals/ArticleMenuModal";
-import ReportModal from "components/Home/Modals/ReportModal";
-import ShareWithModal from "components/Home/Modals/SharerWithModal";
-import { modalActions } from "app/store/ducks/modal/modalSlice";
 
 const Layout = styled.div`
     padding-top: 30px;
@@ -33,27 +25,6 @@ const Layout = styled.div`
 `;
 
 const Home = () => {
-    const {
-        home: { isCopiedNotification },
-        modal: {
-            activatedModal,
-            memberNickname,
-            postId,
-            miniProfile,
-            memberImageUrl,
-        },
-    } = useAppSelector((state) => state);
-
-    const dispatch = useAppDispatch();
-
-    const hoverModalMouseEnterHandler = () => {
-        dispatch(modalActions.mouseOnHoverModal());
-    };
-    const hoverModalMouseLeaveHandler = () => {
-        dispatch(modalActions.mouseNotOnHoverModal());
-        setTimeout(() => dispatch(modalActions.checkMouseOnHoverModal()), 500);
-    };
-
     return (
         <Layout>
             <main>
@@ -61,53 +32,6 @@ const Home = () => {
                 <HomeSection />
             </main>
             <HomeAside />
-            {isCopiedNotification && (
-                <Notification text="링크를 클립보드에 복사했습니다." />
-            )}
-            {miniProfile && (
-                <HoverModal
-                    onMouseEnter={hoverModalMouseEnterHandler}
-                    onMouseLeave={hoverModalMouseLeaveHandler}
-                    miniProfile={miniProfile}
-                />
-            )}
-            {activatedModal === "unfollowing" && (
-                <FollowingModal
-                    onModalOn={() => {
-                        dispatch(modalActions.maintainModalon("unfollowing"));
-                    }}
-                    onModalOff={() =>
-                        dispatch(modalActions.changeActivatedModal(null))
-                    }
-                    memberImageUrl={memberImageUrl}
-                    memberNickname={memberNickname}
-                />
-            )}
-            {activatedModal === "articleMenu" && memberNickname && postId && (
-                <ArticleMenuModal
-                    onModalOn={() =>
-                        dispatch(modalActions.maintainModalon("articleMenu"))
-                    }
-                    onModalOff={() => dispatch(modalActions.resetModal())}
-                />
-            )}
-            {/* 아래 두 모달은 이전 모달을 거쳐야 하므로 필요없는 data는 action에 담지 않음 */}
-            {activatedModal === "report" && (
-                <ReportModal
-                    onModalOn={() =>
-                        dispatch(modalActions.maintainModalon("report"))
-                    }
-                    onModalOff={() => dispatch(modalActions.resetModal())}
-                />
-            )}
-            {activatedModal === "shareWith" && (
-                <ShareWithModal
-                    onModalOn={() =>
-                        dispatch(modalActions.maintainModalon("shareWith"))
-                    }
-                    onModalOff={() => dispatch(modalActions.resetModal())}
-                />
-            )}
         </Layout>
     );
 };


### PR DESCRIPTION
## 개요
`Home` route에만 속해있던 모달들을 다른 routes에서도 사용할 수 있도록 상단 `Routes`로 이동하였습니다.

## 작업사항

-   `Routes`의 `authedContainer`로 공통 모달들을 이동시킴(유저 인증이 완료된 사람만 확인 가능)
- 가시성을 위해 모달들을 `ModalsInEveryRoutes` 컴포넌트로 묶어 분리
- 모달이 떠있는 채로 route 이동 시 모달 비활성화: `Home`만 구현


