### PR TITLE
fix: 스토리 레이아웃 비활성화

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -38,7 +38,7 @@ const Home = () => {
     return (
         <Layout>
             <main>
-                <HomeStories />
+                {/* <HomeStories /> */}
                 <HomeSection />
             </main>
             <HomeAside />


### PR DESCRIPTION
## 개요
당장 필요없는 스토리 레이아웃을 주석 처리하였습니다.
`HomeStories`는 이후에 기능 추가 시 필요할 수 있으므로 제거하지는 않았습니다.
