### PR TITLE
fix: 토큰재발급 에러 발생 시 앱이 멈추는 현상 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ function App() {
                     dispatch(authAction.login());
                 }
                 // - refresh token: 없음 | 만료됨 -> 401에러 -> catch로 넘어감
+            } catch (error) {
+                console.log(error);
             } finally {
                 dispatch(authAction.finishRefreshTokenChecking());
             }


### PR DESCRIPTION
## 개요
예상치 못한 에러가 refresh token 발급 요청 중 발생했을 때 catch문을 통해 한 번 짚어주어 finally문이 정상적으로 실행되도록 합니다.
어떤 에러이건 로그인 화면으로 돌아가면 되기에 간단한 log를 catch문에서 찍고 넘어가도록 하였습니다.