### PR TITLE
fix: npm start 할 때 뜨는 browser caniuse-lite Warning 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5099,9 +5099,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001406",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
-            "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
+            "version": "1.0.30001481",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+            "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5110,6 +5110,10 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ]
         },


### PR DESCRIPTION
```
Browserslist: caniuse-lite is outdated.
Please run: npx browserslist@latest --update-db
Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
```
## 작업사항
- npm run start할 때 뜨는 경고 해결했습니다! 
- 저기 있는 명령어치면 해결되더라구요

## Browserslist
CRA에서 package.json에 browserslist가 있습니다. 어떤 브라우저를 지원하는지 설정하는 거 같고, 여기서 사용하던 모듈이 outdated돼서 Warning이 뜬 거 같네요. 

이런 자료를 참고했습니다. 
https://stackoverflow.com/questions/55510405/what-is-the-significance-of-browserslist-in-package-json-created-by-create-react
